### PR TITLE
Start separate process per file to improve logging

### DIFF
--- a/Sources/FigmaExport/Output/VectorDrawableConverter.swift
+++ b/Sources/FigmaExport/Output/VectorDrawableConverter.swift
@@ -1,21 +1,27 @@
-import Foundation
 import FigmaExportCore
+import Foundation
 
 /// SVG to XML converter
 final class VectorDrawableConverter {
-    
     /// Converts SVG files to XML
-    /// - Parameter inputDirectoryPath: Path to directory with SVG files
-    func convert(inputDirectoryPath: String) throws {
-        let task = Process()
-        task.executableURL = URL(fileURLWithPath: "/usr/local/bin/vd-tool")
-        task.arguments = ["-c", "-in", inputDirectoryPath]
-        do {
-            try task.run()
-        } catch {
-            task.executableURL = URL(fileURLWithPath: "./vd-tool/bin/vd-tool")
-            try task.run()
+    /// - Parameter inputDirectoryUrl: Url to directory with SVG files
+    func convert(inputDirectoryUrl: URL) throws {
+        let enumerator = FileManager.default.enumerator(at: inputDirectoryUrl, includingPropertiesForKeys: nil)
+
+        while let file = enumerator?.nextObject() as? URL {
+            guard file.pathExtension == "svg" else { return }
+            let task = Process()
+            task.executableURL = URL(fileURLWithPath: "/usr/local/bin/vd-tool")
+            task.arguments = ["-c", "-in", file.path, "-out", inputDirectoryUrl.path]
+
+            do {
+                try task.run()
+            } catch {
+                task.executableURL = URL(fileURLWithPath: "./vd-tool/bin/vd-tool")
+                try task.run()
+            }
+
+            task.waitUntilExit()
         }
-        task.waitUntilExit()
     }
 }

--- a/Sources/FigmaExport/Output/VectorDrawableConverter.swift
+++ b/Sources/FigmaExport/Output/VectorDrawableConverter.swift
@@ -1,27 +1,71 @@
 import FigmaExportCore
 import Foundation
+import Logging
 
 /// SVG to XML converter
 final class VectorDrawableConverter {
+    private static let notSupportedWarning = "is not supported"
+    private let logger = Logger(label: "com.redmadrobot.figma-export.vector-drawable-converter")
+
     /// Converts SVG files to XML
+    /// In case unsupported XML-Tags are reported, the converting command will be executed for each file for better logging.
     /// - Parameter inputDirectoryUrl: Url to directory with SVG files
     func convert(inputDirectoryUrl: URL) throws {
-        let enumerator = FileManager.default.enumerator(at: inputDirectoryUrl, includingPropertiesForKeys: nil)
+        let errorPipe = Pipe()
+        let outputPipe = Pipe()
+        let directoryTaskArguments = ["-c", "-in", inputDirectoryUrl.path]
 
-        while let file = enumerator?.nextObject() as? URL {
-            guard file.pathExtension == "svg" else { return }
-            let task = Process()
-            task.executableURL = URL(fileURLWithPath: "/usr/local/bin/vd-tool")
-            task.arguments = ["-c", "-in", file.path, "-out", inputDirectoryUrl.path]
+        try runVdTool(with: directoryTaskArguments, errorPipe: errorPipe, outputPipe: outputPipe)
 
-            do {
-                try task.run()
-            } catch {
-                task.executableURL = URL(fileURLWithPath: "./vd-tool/bin/vd-tool")
-                try task.run()
+        let errorData = errorPipe.fileHandleForReading.readDataToEndOfFile()
+        let error = String(decoding: errorData, as: UTF8.self)
+
+        let outputData = outputPipe.fileHandleForReading.readDataToEndOfFile()
+        let outputString = String(decoding: outputData, as: UTF8.self)
+        // Only log last line out standard output
+        outputString.lastLine.flatMap { logger.info("\($0)") }
+
+        if error.contains(Self.notSupportedWarning) {
+            logger.warning("vd-tool reported unsupported xml tags. Executing vd-tool for each file...")
+            let enumerator = FileManager.default.enumerator(at: inputDirectoryUrl, includingPropertiesForKeys: nil)
+            while let file = enumerator?.nextObject() as? URL {
+                guard file.pathExtension == "svg" else { continue }
+                let fileErrorPipe = Pipe()
+                let fileTaskArguments = ["-c", "-in", file.path, "-out", inputDirectoryUrl.path]
+                logger.info("Converting file: \(file.path)")
+                try runVdTool(with: fileTaskArguments, errorPipe: fileErrorPipe)
+
+                let fileErrorData = fileErrorPipe.fileHandleForReading.readDataToEndOfFile()
+                let fileError = String(decoding: fileErrorData, as: UTF8.self)
+
+                if fileError.contains(Self.notSupportedWarning) {
+                    logger.warning("Error in file: \(file.path)\n\(fileError)")
+                }
             }
-
-            task.waitUntilExit()
         }
+    }
+
+    private func runVdTool(with arguments: [String], errorPipe: Pipe?, outputPipe: Pipe? = nil) throws {
+        let task = Process()
+        task.executableURL = URL(fileURLWithPath: "/usr/local/bin/vd-tool")
+        task.arguments = arguments
+
+        task.standardOutput = outputPipe
+        task.standardError = errorPipe
+
+        do {
+            try task.run()
+        } catch {
+            task.executableURL = URL(fileURLWithPath: "./vd-tool/bin/vd-tool")
+            try task.run()
+        }
+
+        task.waitUntilExit()
+    }
+}
+
+private extension String {
+    var lastLine: String? {
+        split { $0 == "\n" }.compactMap(String.init).last
     }
 }

--- a/Sources/FigmaExport/Subcommands/ExportIcons.swift
+++ b/Sources/FigmaExport/Subcommands/ExportIcons.swift
@@ -142,7 +142,7 @@ extension FigmaExportCommand {
             
             // 5. Convert all SVG to XML files
             logger.info("Converting SVGs to XMLs...")
-            try svgFileConverter.convert(inputDirectoryPath: tempDirectoryURL.path)
+            try svgFileConverter.convert(inputDirectoryUrl: tempDirectoryURL)
             
             // Create output directory main/res/custom-directory/drawable/
             let outputDirectory = URL(fileURLWithPath: android.mainRes

--- a/Sources/FigmaExport/Subcommands/ExportImages.swift
+++ b/Sources/FigmaExport/Subcommands/ExportImages.swift
@@ -162,10 +162,10 @@ extension FigmaExportCommand {
             
             // Convert all SVG to XML files
             logger.info("Converting SVGs to XMLs...")
-            try svgFileConverter.convert(inputDirectoryPath: tempDirectoryLightURL.path)
+            try svgFileConverter.convert(inputDirectoryUrl: tempDirectoryLightURL)
             if images.first?.dark != nil {
                 logger.info("Converting dark SVGs to XMLs...")
-                try svgFileConverter.convert(inputDirectoryPath: tempDirectoryDarkURL.path)
+                try svgFileConverter.convert(inputDirectoryUrl: tempDirectoryDarkURL)
             }
 
             logger.info("Writting files to Android Studio project...")


### PR DESCRIPTION
I encountered a problem with exporting icons to XML for android. In case there are unsupported XML-Tags in the SVG files for the vd-tool it only tells you that there was an error. But it does not tell you in which file. So it is pretty hard to see which assets in Figma are not built correctly.

This is a suggestion to start a separate process for each file, which makes it possible to read from the logs, which file had issues while converting.

The downside is, that starting a process for each file makes the whole thing take way longer. A proper solution would probably be to adjust the vd-tool, which is not easily doable, as this tool is also just a packaging of the Android Studio VectorDrawable CLI tool.

Maybe you have a suggestion to improve this behavior.