### PR TITLE
Fixed directory creation of dark svg images

### DIFF
--- a/Sources/FigmaExport/Subcommands/ExportImages.swift
+++ b/Sources/FigmaExport/Subcommands/ExportImages.swift
@@ -150,7 +150,7 @@ extension FigmaExportCommand {
                 }
                 let darkFiles = asset.dark?.images.map { image -> FileContents in
                     let fileURL = URL(string: "\(image.name).svg")!
-                    let dest = Destination(directory: tempDirectoryLightURL, file: fileURL)
+                    let dest = Destination(directory: tempDirectoryDarkURL, file: fileURL)
                     return FileContents(destination: dest, sourceURL: image.url, dark: true)
                 } ?? []
                 return lightFiles + darkFiles


### PR DESCRIPTION
Dark files were using the light directory url