### PR TITLE
Fixed “Error: Missing expected argument”

### DIFF
--- a/Sources/FigmaExport/Input/FigmaExportOptions.swift
+++ b/Sources/FigmaExport/Input/FigmaExportOptions.swift
@@ -8,7 +8,7 @@ struct FigmaExportOptions: ParsableArguments {
     @Option(name: .shortAndLong, help: "An input YAML file with figma and platform properties.")
     var input: String = Self.input
 
-    var accessToken: String = ""
+    var accessToken: String!
 
     var params: Params!
 


### PR DESCRIPTION
### Description

The `figma-export` commands are not working.
It returns this error for subcommands.

```
Error: Missing expected argument
Usage: figma-export (images, icons) [--input <input>] [<filter>]
  See 'figma-export (images, icons) --help' for more information.
```
### Issue

I found out that the `access_token` needs to be defined as `String!`, otherwise it will take it as required argument.