### PR TITLE
Only convert solid fills to colors

### DIFF
--- a/Sources/FigmaAPI/Model/Node.swift
+++ b/Sources/FigmaAPI/Model/Node.swift
@@ -38,10 +38,37 @@ public struct Document: Decodable {
     public let style: TypeStyle?
 }
 
+// https://www.figma.com/plugin-docs/api/Paint/
 public struct Paint: Decodable {
-    public let type: String
+    public let type: PaintType
+    public let opacity: Double?
+    public let color: PaintColor?
+
+    public var asSolid: SolidPaint? {
+        return SolidPaint(self)
+    }
+}
+
+public enum PaintType: String, Decodable {
+    case solid = "SOLID"
+    case image = "IMAGE"
+    case rectangle = "RECTANGLE"
+    case gradientLinear = "GRADIENT_LINEAR"
+    case gradientRadial = "GRADIENT_RADIAL"
+    case gradientAngular = "GRADIENT_ANGULAR"
+    case gradientDiamond = "GRADIENT_DIAMOND"
+}
+
+public struct SolidPaint: Decodable {
     public let opacity: Double?
     public let color: PaintColor
+
+    public init?(_ paint: Paint) {
+        guard paint.type == .solid else { return nil }
+        guard let color = paint.color else { return nil }
+        self.opacity = paint.opacity
+        self.color = color
+    }
 }
 
 public struct PaintColor: Decodable {

--- a/Sources/FigmaExport/Loaders/ColorsLoader.swift
+++ b/Sources/FigmaExport/Loaders/ColorsLoader.swift
@@ -34,8 +34,8 @@ final class ColorsLoader {
     /// Соотносит массив Style и Node чтобы получит массив Color
     private func nodesAndStylesToColors(nodes: [NodeId: Node], styles: [Style]) -> [Color] {
         return styles.compactMap { style -> Color? in
-            guard let node = nodes[style.nodeId] else { return nil}
-            guard let fill = node.document.fills.first else { return nil }
+            guard let node = nodes[style.nodeId] else { return nil }
+            guard let fill = node.document.fills.first?.asSolid else { return nil }
             let alpha: Double = fill.opacity ?? fill.color.a
             let platform = Platform(rawValue: style.description)
             


### PR DESCRIPTION
Hi there

When I run `figma-export colors` on my project, there's a decoding error as follows:

```
$ figma-export --version
0.18.6

$ figma-export colors -i figma-export.yaml 
2020-12-29T13:13:30+0900 info com.redmadrobot.figma-export : Using FigmaExport to export colors.
2020-12-29T13:13:30+0900 info com.redmadrobot.figma-export : Fetching colors. Please wait...
Error: keyNotFound(CodingKeys(stringValue: "color", intValue: nil), Swift.DecodingError.Context(codingPath: [CodingKeys(stringValue: "nodes", intValue: nil), _JSONKey(stringValue: "1:66", intValue: nil), CodingKeys(stringValue: "document", intValue: nil), CodingKeys(stringValue: "fills", intValue: nil), _JSONKey(stringValue: "Index 0", intValue: 0)], debugDescription: "No value associated with key CodingKeys(stringValue: \"color\", intValue: nil) (\"color\").", underlyingError: nil))
```

This is because the key `color` is only defined in a paint of type `SOLID` according to the [figma API reference](https://www.figma.com/plugin-docs/api/Paint/). My project has paints of type `IMAGE` which don't have `color` and that's why the decoding error came out.

This PR makes the property `color` of `Paint` optional and replaces `type: String` with `type: PaintType` so that we can distinguish each paint type.