### PR TITLE
Added timeout options

### DIFF
--- a/CONFIG.md
+++ b/CONFIG.md
@@ -15,6 +15,8 @@ figma:
   lightFileId: shPilWnVdJfo10YF12345
   # [optional] Identifier of the file containing dark color palette and dark images.
   darkFileId: KfF6DnJTWHGZzC912345
+  # [optional] Figma API request timeout, default is 30s
+  # timeout: 30
 
 # [optional] Common export parameters
 common:

--- a/CONFIG.md
+++ b/CONFIG.md
@@ -15,7 +15,7 @@ figma:
   lightFileId: shPilWnVdJfo10YF12345
   # [optional] Identifier of the file containing dark color palette and dark images.
   darkFileId: KfF6DnJTWHGZzC912345
-  # [optional] Figma API request timeout, default is 30s
+  # [optional] Figma API request timeout. The default value of this property is 30 (seconds). If you have a lot of resources to export set this value to 60 or more to give Figma API more time to prepare resources for exporting.
   # timeout: 30
 
 # [optional] Common export parameters

--- a/Sources/FigmaAPI/FigmaClient.swift
+++ b/Sources/FigmaAPI/FigmaClient.swift
@@ -7,11 +7,11 @@ final public class FigmaClient {
     private let baseURL = URL(string: "https://api.figma.com/v1/")!
     
     private let session: URLSession
-    
-    public init(accessToken: String) {
+
+    public init(accessToken: String, timeout: TimeInterval?) {
         let config = URLSessionConfiguration.ephemeral
         config.httpAdditionalHeaders = ["X-Figma-Token": accessToken]
-        config.timeoutIntervalForRequest = 30
+        config.timeoutIntervalForRequest = timeout ?? 30
         session = URLSession(configuration: config, delegate: nil, delegateQueue: .main)
     }
     

--- a/Sources/FigmaExport/Input/Params.swift
+++ b/Sources/FigmaExport/Input/Params.swift
@@ -8,6 +8,7 @@ struct Params: Decodable {
     struct Figma: Decodable {
         let lightFileId: String
         let darkFileId: String?
+        let timeout: TimeInterval?
     }
     
     struct Common: Decodable {

--- a/Sources/FigmaExport/Resources/androidConfig.swift
+++ b/Sources/FigmaExport/Resources/androidConfig.swift
@@ -5,7 +5,7 @@ figma:
   lightFileId: shPilWnVdJfo10YF12345
   # [optional] Identifier of the file containing dark color palette and dark images.
   darkFileId: KfF6DnJTWHGZzC912345
-  # [optional] Figma API request timeout, default is 30s
+  # [optional] Figma API request timeout. The default value of this property is 30 (seconds). If you have a lot of resources to export set this value to 60 or more to give Figma API more time to prepare resources for exporting.
   # timeout: 30
 
 # [optional] Android export parameters

--- a/Sources/FigmaExport/Resources/androidConfig.swift
+++ b/Sources/FigmaExport/Resources/androidConfig.swift
@@ -5,6 +5,8 @@ figma:
   lightFileId: shPilWnVdJfo10YF12345
   # [optional] Identifier of the file containing dark color palette and dark images.
   darkFileId: KfF6DnJTWHGZzC912345
+  # [optional] Figma API request timeout, default is 30s
+  # timeout: 30
 
 # [optional] Android export parameters
 android:

--- a/Sources/FigmaExport/Resources/iOSConfig.swift
+++ b/Sources/FigmaExport/Resources/iOSConfig.swift
@@ -5,7 +5,7 @@ figma:
   lightFileId: shPilWnVdJfo10YF12345
   # [optional] Identifier of the file containing dark color palette and dark images.
   darkFileId: KfF6DnJTWHGZzC912345
-  # [optional] Figma API request timeout, default is 30s
+  # [optional] Figma API request timeout. The default value of this property is 30 (seconds). If you have a lot of resources to export set this value to 60 or more to give Figma API more time to prepare resources for exporting.
   # timeout: 30
 
 # [optional] Common export parameters

--- a/Sources/FigmaExport/Resources/iOSConfig.swift
+++ b/Sources/FigmaExport/Resources/iOSConfig.swift
@@ -5,6 +5,8 @@ figma:
   lightFileId: shPilWnVdJfo10YF12345
   # [optional] Identifier of the file containing dark color palette and dark images.
   darkFileId: KfF6DnJTWHGZzC912345
+  # [optional] Figma API request timeout, default is 30s
+  # timeout: 30
 
 # [optional] Common export parameters
 common:

--- a/Sources/FigmaExport/Subcommands/ExportColors.swift
+++ b/Sources/FigmaExport/Subcommands/ExportColors.swift
@@ -20,7 +20,7 @@ extension FigmaExportCommand {
         
         func run() throws {
             let logger = Logger(label: "com.redmadrobot.figma-export")
-            let client = FigmaClient(accessToken: options.accessToken)
+            let client = FigmaClient(accessToken: options.accessToken, timeout: options.params.figma.timeout)
 
             logger.info("Using FigmaExport to export colors.")
 

--- a/Sources/FigmaExport/Subcommands/ExportIcons.swift
+++ b/Sources/FigmaExport/Subcommands/ExportIcons.swift
@@ -27,7 +27,7 @@ extension FigmaExportCommand {
         
         func run() throws {
             let logger = Logger(label: "com.redmadrobot.figma-export")
-            let client = FigmaClient(accessToken: options.accessToken)
+            let client = FigmaClient(accessToken: options.accessToken, timeout: options.params.figma.timeout)
             
             if options.params.ios != nil {
                 logger.info("Using FigmaExport to export icons to Xcode project.")

--- a/Sources/FigmaExport/Subcommands/ExportImages.swift
+++ b/Sources/FigmaExport/Subcommands/ExportImages.swift
@@ -27,7 +27,7 @@ extension FigmaExportCommand {
         
         func run() throws {
             let logger = Logger(label: "com.redmadrobot.figma-export")
-            let client = FigmaClient(accessToken: options.accessToken)
+            let client = FigmaClient(accessToken: options.accessToken, timeout: options.params.figma.timeout)
 
             if let _ = options.params.ios {
                 logger.info("Using FigmaExport to export images to Xcode project.")

--- a/Sources/FigmaExport/Subcommands/ExportTypography.swift
+++ b/Sources/FigmaExport/Subcommands/ExportTypography.swift
@@ -20,7 +20,7 @@ extension FigmaExportCommand {
         
         func run() throws {
             let logger = Logger(label: "com.redmadrobot.figma-export")
-            let client = FigmaClient(accessToken: options.accessToken)
+            let client = FigmaClient(accessToken: options.accessToken, timeout: options.params.figma.timeout)
 
             logger.info("Using FigmaExport to export typography.")
 


### PR DESCRIPTION
## Description

Our Figma file has too many assets. The default timeout is not enough for us to get all assets.

## Changes

- Add timeout option to change default request timeout. 