### PR TITLE
Fix baselineOffset

### DIFF
--- a/Examples/Example/UIComponents/Source/LabelStyle.swift
+++ b/Examples/Example/UIComponents/Source/LabelStyle.swift
@@ -32,14 +32,11 @@ struct LabelStyle {
         var baselineOffset: CGFloat = .zero
         
         if let lineHeight = lineHeight {
-            let lineHeightMultiple = lineHeight / font.lineHeight
-            paragraphStyle.lineHeightMultiple = lineHeightMultiple
-            
-            baselineOffset = 1 / lineHeightMultiple
-            
             let scaledLineHeight: CGFloat = fontMetrics?.scaledValue(for: lineHeight) ?? lineHeight
             paragraphStyle.minimumLineHeight = scaledLineHeight
             paragraphStyle.maximumLineHeight = scaledLineHeight
+
+            baselineOffset = (scaledLineHeight - font.lineHeight) / 4.0
         }
         
         return [

--- a/Sources/XcodeExport/XcodeTypographyExporter.swift
+++ b/Sources/XcodeExport/XcodeTypographyExporter.swift
@@ -223,14 +223,11 @@ struct LabelStyle {
         var baselineOffset: CGFloat = .zero
         
         if let lineHeight = lineHeight {
-            let lineHeightMultiple = lineHeight / font.lineHeight
-            paragraphStyle.lineHeightMultiple = lineHeightMultiple
-            
-            baselineOffset = 1 / lineHeightMultiple
-            
             let scaledLineHeight: CGFloat = fontMetrics?.scaledValue(for: lineHeight) ?? lineHeight
             paragraphStyle.minimumLineHeight = scaledLineHeight
             paragraphStyle.maximumLineHeight = scaledLineHeight
+            
+            baselineOffset = (scaledLineHeight - font.lineHeight) / 4.0
         }
         
         return [

--- a/Tests/XcodeExportTests/XcodeTypographyExporterTests.swift
+++ b/Tests/XcodeExportTests/XcodeTypographyExporterTests.swift
@@ -311,14 +311,11 @@ final class XcodeTypographyExporterTests: XCTestCase {
                 var baselineOffset: CGFloat = .zero
                 
                 if let lineHeight = lineHeight {
-                    let lineHeightMultiple = lineHeight / font.lineHeight
-                    paragraphStyle.lineHeightMultiple = lineHeightMultiple
-                    
-                    baselineOffset = 1 / lineHeightMultiple
-                    
                     let scaledLineHeight: CGFloat = fontMetrics?.scaledValue(for: lineHeight) ?? lineHeight
                     paragraphStyle.minimumLineHeight = scaledLineHeight
                     paragraphStyle.maximumLineHeight = scaledLineHeight
+                    
+                    baselineOffset = (scaledLineHeight - font.lineHeight) / 4.0
                 }
                 
                 return [


### PR DESCRIPTION
Fixed `baselineOffset` calculation.

<img width="1272" alt="Screen Shot 2021-01-29 at 17 33 56" src="https://user-images.githubusercontent.com/410293/106288201-c8c61180-6258-11eb-81e8-12fcb65ee703.png">
<img width="1405" alt="Screen Shot 2021-01-29 at 17 33 24" src="https://user-images.githubusercontent.com/410293/106288208-cb286b80-6258-11eb-84d4-3b81f0819533.png">
