### PR TITLE
Add modifyXcodeproj param to opt out of .xcodeproj codegen

### DIFF
--- a/Sources/FigmaExport/Input/Params.swift
+++ b/Sources/FigmaExport/Input/Params.swift
@@ -48,6 +48,7 @@ struct Params: Decodable {
             
             let colorSwift: URL?
             let swiftuiColorSwift: URL?
+            let modifyXcodeproj: Bool
         }
         
         struct Icons: Decodable {
@@ -75,6 +76,7 @@ struct Params: Decodable {
             let swiftUIFontSwift: URL?
             let generateLabels: Bool
             let labelsDirectory: URL?
+            let modifyXcodeproj: Bool
         }
         
         let xcodeprojPath: String

--- a/Sources/FigmaExport/Subcommands/ExportColors.swift
+++ b/Sources/FigmaExport/Subcommands/ExportColors.swift
@@ -79,7 +79,8 @@ extension FigmaExportCommand {
                 assetsColorsURL: colorsURL,
                 assetsInMainBundle: iosParams.xcassetsInMainBundle,
                 colorSwiftURL: iosParams.colors.colorSwift,
-                swiftuiColorSwiftURL: iosParams.colors.swiftuiColorSwift)
+                swiftuiColorSwiftURL: iosParams.colors.swiftuiColorSwift,
+                modifyXcodeproj: iosParams.colors.modifyXcodeproj)
 
             let exporter = XcodeColorExporter(output: output)
             let files = exporter.export(colorPairs: colorPairs)
@@ -89,7 +90,9 @@ extension FigmaExportCommand {
             }
             
             try fileWritter.write(files: files)
-            
+
+            guard iosParams.colors.modifyXcodeproj else { return }
+
             do {
                 let xcodeProject = try XcodeProjectWritter(xcodeProjPath: iosParams.xcodeprojPath, target: iosParams.target)
                 try files.forEach { file in

--- a/Sources/FigmaExport/Subcommands/ExportTypography.swift
+++ b/Sources/FigmaExport/Subcommands/ExportTypography.swift
@@ -66,6 +66,8 @@ extension FigmaExportCommand {
                 ))
             }
             try fileWritter.write(files: files)
+
+            guard iosParams.typography.modifyXcodeproj else { return }
             
             do {
                 let xcodeProject = try XcodeProjectWritter(xcodeProjPath: iosParams.xcodeprojPath, target: iosParams.target)

--- a/Sources/XcodeExport/Model/XcodeColorsOutput.swift
+++ b/Sources/XcodeExport/Model/XcodeColorsOutput.swift
@@ -6,11 +6,13 @@ public struct XcodeColorsOutput {
     public let assetsInMainBundle: Bool
     public let colorSwiftURL: URL?
     public let swiftuiColorSwiftURL: URL?
+    public let modifyXcodeproj: Bool
     
-    public init(assetsColorsURL: URL?, assetsInMainBundle: Bool, colorSwiftURL: URL? = nil, swiftuiColorSwiftURL: URL? = nil) {
+    public init(assetsColorsURL: URL?, assetsInMainBundle: Bool, colorSwiftURL: URL? = nil, swiftuiColorSwiftURL: URL? = nil, modifyXcodeproj: Bool = true) {
         self.assetsColorsURL = assetsColorsURL
         self.assetsInMainBundle = assetsInMainBundle
         self.colorSwiftURL = colorSwiftURL
         self.swiftuiColorSwiftURL = swiftuiColorSwiftURL
+        self.modifyXcodeproj = modifyXcodeproj
     }
 }


### PR DESCRIPTION
Modifying the .xcodeproj with codegen is a powerful feature -- but we would like to disable this for the font and color extension files.