### PR TITLE
Support exporting colors from a single figma file

### DIFF
--- a/CONFIG.md
+++ b/CONFIG.md
@@ -26,6 +26,10 @@ common:
     nameValidateRegexp: '^[a-zA-Z_]+$' # RegExp pattern for: background, background_primary, widget_primary_background
     # [optional] RegExp pattern for replacing. Supports only $n
     nameReplaceRegexp: 'color_$1'
+    # [optional] Extract light and dark mode colors from the lightFileId specified in the figma params.
+    useSingleFile: true
+    # [optional] If useSingleFile is true, customize the suffix to denote a dark mode color. Defaults to '_dark'
+    darkModeSuffix: '_dark'
   # [optional]
   icons:
     # [optional] Name of the Figma's frame where icons components are located
@@ -57,7 +61,7 @@ ios:
   # Parameters for exporting colors
   colors:
     # How to export colors? Use .xcassets and UIColor extension (useColorAssets = true) or extension only (useColorAssets = false)
-    useColorAssets: True
+    useColorAssets: true
     # [required if useColorAssets: True] Name of the folder inside Assets.xcassets where to place colors (.colorset directories)
     assetsFolder: Colors
     # Color name style: camelCase or snake_case

--- a/CONFIG.md
+++ b/CONFIG.md
@@ -26,7 +26,7 @@ common:
     nameValidateRegexp: '^[a-zA-Z_]+$' # RegExp pattern for: background, background_primary, widget_primary_background
     # [optional] RegExp pattern for replacing. Supports only $n
     nameReplaceRegexp: 'color_$1'
-    # [optional] Extract light and dark mode colors from the lightFileId specified in the figma params.
+    # [optional] Extract light and dark mode colors from the lightFileId specified in the figma params. Defaults to false
     useSingleFile: true
     # [optional] If useSingleFile is true, customize the suffix to denote a dark mode color. Defaults to '_dark'
     darkModeSuffix: '_dark'

--- a/README.md
+++ b/README.md
@@ -352,7 +352,7 @@ If a color, icon or image is unique for iOS or Android platform, it should conta
 
 For `figma-export colors`
 
-If you support dark mode your figma project must contains two files. One should contains a dark color palette, and the another light color palette. Names and number of the colors must matches.
+By default, if you support dark mode your figma project must contains two files. One should contains a dark color palette, and the another light color palette. Names and number of the colors must matches. If you would like to specify light and dark colors in the same file, you can do so with the `useSingleFile` configuration option. You can then denote dark mode colors by adding a suffix like `_dark`. The suffix is also configurable. See [config](Config.md) for more information in the colors section.
 
 Example
 

--- a/Sources/FigmaExport/Input/Params.swift
+++ b/Sources/FigmaExport/Input/Params.swift
@@ -15,6 +15,8 @@ struct Params: Decodable {
         struct Colors: Decodable {
             let nameValidateRegexp: String?
             let nameReplaceRegexp: String?
+            let useSingleFile: Bool?
+            let darkModeSuffix: String?
         }
         
         struct Icons: Decodable {

--- a/Sources/FigmaExport/Loaders/ColorsLoader.swift
+++ b/Sources/FigmaExport/Loaders/ColorsLoader.swift
@@ -34,7 +34,7 @@ final class ColorsLoader {
         let colors = try loadColors(fileId: figmaParams.lightFileId)
         let darkSuffix = colorParams?.darkModeSuffix ?? "_dark"
         let lightColors = colors
-            .filter { !$0.name.hasSuffix(darkSuffix)}
+            .filter { !$0.name.hasSuffix(darkSuffix) }
         let darkColors = colors
             .filter { $0.name.hasSuffix(darkSuffix) }
             .map { color -> Color in

--- a/Sources/FigmaExport/Loaders/ColorsLoader.swift
+++ b/Sources/FigmaExport/Loaders/ColorsLoader.swift
@@ -15,8 +15,17 @@ final class ColorsLoader {
     }
     
     func load() throws -> (light: [Color], dark: [Color]?) {
-        let lightColors = try loadColors(fileId: params.lightFileId)
-        let darkColors = try params.darkFileId.map { try loadColors(fileId: $0) }
+        let colors = try loadColors(fileId: params.lightFileId)
+        let darkSuffix = "_dark"
+        let lightColors = colors
+            .filter { !$0.name.hasSuffix(darkSuffix)}
+        let darkColors = colors
+            .filter { $0.name.hasSuffix(darkSuffix) }
+            .map { color -> Color in
+                var newColor = color
+                newColor.name = String(color.name.dropLast(darkSuffix.count))
+                return newColor
+            }
         return (lightColors, darkColors)
     }
     

--- a/Sources/FigmaExport/Subcommands/ExportColors.swift
+++ b/Sources/FigmaExport/Subcommands/ExportColors.swift
@@ -25,7 +25,7 @@ extension FigmaExportCommand {
             logger.info("Using FigmaExport \(FigmaExportCommand.version) to export colors.")
 
             logger.info("Fetching colors. Please wait...")
-            let loader = ColorsLoader(figmaClient: client, params: options.params.figma)
+            let loader = ColorsLoader(figmaClient: client, figmaParams: options.params.figma, colorParams: options.params.common?.colors)
             let colors = try loader.load()
 
             if let ios = options.params.ios {
@@ -34,7 +34,9 @@ extension FigmaExportCommand {
                     platform: .ios,
                     nameValidateRegexp: options.params.common?.colors?.nameValidateRegexp,
                     nameReplaceRegexp: options.params.common?.colors?.nameReplaceRegexp,
-                    nameStyle: options.params.ios?.colors.nameStyle
+                    nameStyle: options.params.ios?.colors.nameStyle,
+                    useSingleFile: options.params.common?.colors?.useSingleFile,
+                    darkModeSuffix: options.params.common?.colors?.darkModeSuffix
                 )
                 let colorPairs = try processor.process(light: colors.light, dark: colors.dark).get()
 
@@ -52,7 +54,9 @@ extension FigmaExportCommand {
                     platform: .android,
                     nameValidateRegexp: options.params.common?.colors?.nameValidateRegexp,
                     nameReplaceRegexp: options.params.common?.colors?.nameReplaceRegexp,
-                    nameStyle: .snakeCase
+                    nameStyle: .snakeCase,
+                    useSingleFile: options.params.common?.colors?.useSingleFile,
+                    darkModeSuffix: options.params.common?.colors?.darkModeSuffix
                 )
                 let colorPairs = try processor.process(light: colors.light, dark: colors.dark).get()
 

--- a/Sources/FigmaExportCore/Processor/AssetsProcessor.swift
+++ b/Sources/FigmaExportCore/Processor/AssetsProcessor.swift
@@ -47,12 +47,16 @@ public struct ColorsProcessor: AssetsProcessable {
     public let nameValidateRegexp: String?
     public let nameReplaceRegexp: String?
     public let nameStyle: NameStyle?
+    public let useSingleFile: Bool?
+    public let darkModeSuffix: String?
     
-    public init(platform: Platform, nameValidateRegexp: String?, nameReplaceRegexp: String?, nameStyle: NameStyle?) {
+    public init(platform: Platform, nameValidateRegexp: String?, nameReplaceRegexp: String?, nameStyle: NameStyle?, useSingleFile: Bool?, darkModeSuffix: String?) {
         self.platform = platform
         self.nameValidateRegexp = nameValidateRegexp
         self.nameReplaceRegexp = nameReplaceRegexp
         self.nameStyle = nameStyle
+        self.useSingleFile = useSingleFile
+        self.darkModeSuffix = darkModeSuffix
     }
 }
 


### PR DESCRIPTION
Resolves #66 

Adds two configuration options to the common:colors: portion of the yaml file. When `useSingleFile` is true, it will only read from the `lightFileId` specified in the figma options. It will look for dark colors as specified by a color style ending in `_dark` (configurable via the `darkModeSuffix` config option).

I wasn't able to write a test for this as the ColorsLoader is hard-wired to hit the Figma API, but I updated the docs and tested things out on my end.