### PR TITLE
Add iOS illustration scales to the config file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -88,3 +88,7 @@ fastlane/test_output
 # https://github.com/johnno1962/injectionforxcode
 
 iOSInjectionProject/
+
+# Other
+
+.DS_Store

--- a/CONFIG.md
+++ b/CONFIG.md
@@ -99,7 +99,7 @@ ios:
     assetsFolder: Illustrations
     # Image name style: camelCase or snake_case
     nameStyle: camelCase
-    # An array of asset scales that should be downloaded. The valid values are 1, 2, 3.
+    # [optional] An array of asset scales that should be downloaded. The valid values are 1, 2, 3. The deafault value is [1, 2, 3].
     scales: [1, 2, 3]
     # [optional] Absolute or relative path to swift file where to export images (SwiftUI’s Image) for accessing from the code (e.g. Image.illZeroNoInternet)
     swiftUIImageSwift: "./Source/Image+extension_illustrations.swift"

--- a/CONFIG.md
+++ b/CONFIG.md
@@ -22,7 +22,7 @@ figma:
 common:
   # [optional]
   colors:
-    # [optional] RegExp pattern for color name validation before exporting 
+    # [optional] RegExp pattern for color name validation before exporting
     nameValidateRegexp: '^[a-zA-Z_]+$' # RegExp pattern for: background, background_primary, widget_primary_background
     # [optional] RegExp pattern for replacing. Supports only $n
     nameReplaceRegexp: 'color_$1'
@@ -34,7 +34,7 @@ common:
   icons:
     # [optional] Name of the Figma's frame where icons components are located
     figmaFrameName: Icons
-    # [optional] RegExp pattern for icon name validation before exporting 
+    # [optional] RegExp pattern for icon name validation before exporting
     nameValidateRegexp: '^(ic)_(\d\d)_([a-z0-9_]+)$' # RegExp pattern for: ic_24_icon_name, ic_24_icon
     # [optional] RegExp pattern for replacing. Supports only $n
     nameReplaceRegexp: 'icon_$2_$1'
@@ -99,6 +99,8 @@ ios:
     assetsFolder: Illustrations
     # Image name style: camelCase or snake_case
     nameStyle: camelCase
+    # An array of asset scales that should be downloaded. The valid values are 1, 2, 3.
+    scales: [1, 2, 3]
     # [optional] Absolute or relative path to swift file where to export images (SwiftUI’s Image) for accessing from the code (e.g. Image.illZeroNoInternet)
     swiftUIImageSwift: "./Source/Image+extension_illustrations.swift"
     # [optional] Absolute or relative path to swift file where to generate extension for UIImage for accessing illustrations from the code (e.g. UIImage.illZeroNoInternet)

--- a/Sources/FigmaExport/Input/Params.swift
+++ b/Sources/FigmaExport/Input/Params.swift
@@ -10,7 +10,7 @@ struct Params: Decodable {
         let darkFileId: String?
         let timeout: TimeInterval?
     }
-    
+
     struct Common: Decodable {
         struct Colors: Decodable {
             let nameValidateRegexp: String?
@@ -18,67 +18,68 @@ struct Params: Decodable {
             let useSingleFile: Bool?
             let darkModeSuffix: String?
         }
-        
+
         struct Icons: Decodable {
             let nameValidateRegexp: String?
             let figmaFrameName: String?
             let nameReplaceRegexp: String?
         }
-        
+
         struct Images: Decodable {
             let nameValidateRegexp: String?
             let figmaFrameName: String?
             let nameReplaceRegexp: String?
         }
-        
+
         let colors: Colors?
         let icons: Icons?
         let images: Images?
     }
-    
+
     enum VectorFormat: String, Decodable {
         case pdf
         case svg
     }
-    
+
     struct iOS: Decodable {
-        
+
         struct Colors: Decodable {
             let useColorAssets: Bool
             let assetsFolder: String?
             let nameStyle: NameStyle
-            
+
             let colorSwift: URL?
             let swiftuiColorSwift: URL?
         }
-        
+
         struct Icons: Decodable {
             let format: VectorFormat
             let assetsFolder: String
             let preservesVectorRepresentation: [String]?
             let nameStyle: NameStyle
-            
+
             let imageSwift: URL?
             let swiftUIImageSwift: URL?
-            
+
             let renderMode: XcodeRenderMode?
         }
 
         struct Images: Decodable {
             let assetsFolder: String
             let nameStyle: NameStyle
-            
+            let scales: [Double]?
+
             let imageSwift: URL?
             let swiftUIImageSwift: URL?
         }
-        
+
         struct Typography: Decodable {
             let fontSwift: URL?
             let swiftUIFontSwift: URL?
             let generateLabels: Bool
             let labelsDirectory: URL?
         }
-        
+
         let xcodeprojPath: String
         let target: String
         let xcassetsPath: URL

--- a/Sources/FigmaExport/Loaders/ImagesLoader.swift
+++ b/Sources/FigmaExport/Loaders/ImagesLoader.swift
@@ -171,7 +171,7 @@ final class ImagesLoader {
         } else {
             let validScales: [Double] = [1, 2, 3]
             let customScales = params.ios?.images.scales?.filter { validScales.contains($0) } ?? []
-            return !customScales.isEmpty ? customScales : validScales
+            return customScales.isEmpty ? validScales : customScales
         }
     }
 

--- a/Sources/FigmaExport/Loaders/ImagesLoader.swift
+++ b/Sources/FigmaExport/Loaders/ImagesLoader.swift
@@ -7,15 +7,15 @@ final class ImagesLoader {
     let figmaClient: FigmaClient
     let params: Params
     let platform: Platform
-    
+
     private var iconsFrameName: String {
         params.common?.icons?.figmaFrameName ?? "Icons"
     }
-    
+
     private var imagesFrameName: String {
         params.common?.images?.figmaFrameName ?? "Illustrations"
     }
-    
+
     init(figmaClient: FigmaClient, params: Params, platform: Platform) {
         self.figmaClient = figmaClient
         self.params = params
@@ -67,7 +67,7 @@ final class ImagesLoader {
                 frameName: imagesFrameName,
                 params: SVGParams(),
                 filter: filter)
-            
+
             let darkPacks = try params.figma.darkFileId.map {
                 try _loadImages(
                     fileId: $0,
@@ -88,14 +88,14 @@ final class ImagesLoader {
                     ($0.description == platform.rawValue || $0.description == nil || $0.description == "") &&
                     $0.description?.contains("none") == false
             }
-        
+
         if let filter = filter {
             let assetsFilter = AssetsFilter(filter: filter)
             components = components.filter { component -> Bool in
                 assetsFilter.match(name: component.name)
             }
         }
-        
+
         return Dictionary(uniqueKeysWithValues: components.map { ($0.nodeId, $0) })
     }
 
@@ -106,11 +106,11 @@ final class ImagesLoader {
         filter: String? = nil
     ) throws -> [ImagePack] {
         let imagesDict = try fetchImageComponents(fileId: fileId, frameName: frameName, filter: filter)
-        
+
         guard !imagesDict.isEmpty else {
             throw FigmaExportError.componentsNotFound
         }
-        
+
         let imagesIds: [NodeId] = imagesDict.keys.map { $0 }
         let imageIdToImagePath = try loadImages(fileId: fileId, nodeIds: imagesIds, params: params)
 
@@ -133,13 +133,13 @@ final class ImagesLoader {
 
     private func loadPNGImages(fileId: String, frameName: String, filter: String? = nil, platform: Platform) throws -> [ImagePack] {
         let imagesDict = try fetchImageComponents(fileId: fileId, frameName: frameName, filter: filter)
-        
+
         guard !imagesDict.isEmpty else {
             throw FigmaExportError.componentsNotFound
         }
 
         let imagesIds: [NodeId] = imagesDict.keys.map { $0 }
-        let scales = platform == .android ? [1, 2, 3, 1.5, 4.0] : [1, 2, 3]
+        let scales = getScales(platform: platform)
 
         var images: [Double: [NodeId: ImagePath]] = [:]
         for scale in scales {
@@ -163,6 +163,16 @@ final class ImagesLoader {
             return ImagePack(name: packName, images: packImages, platform: platform)
         }
         return imagePacks
+    }
+
+    private func getScales(platform: Platform) -> [Double] {
+        if platform == .android {
+            return [1, 2, 3, 1.5, 4.0]
+        } else {
+            let validScales: [Double] = [1, 2, 3]
+            let customScales = params.ios?.images.scales?.filter { validScales.contains($0) } ?? []
+            return !customScales.isEmpty ? customScales : validScales
+        }
     }
 
     // MARK: - Figma


### PR DESCRIPTION
There are no phones with a 1x display scale supporting the latest OS versions. So, we don't have to download 1x assets. This is why I added the `scales` parameter into the config file which gives an ability to choose appropriate scales for your project.

* Sorry for the changes of empty lines. I can revert them if it's necessary.