### PR TITLE
Make file download requests chunked

### DIFF
--- a/Sources/FigmaExport/Loaders/ImagesLoader.swift
+++ b/Sources/FigmaExport/Loaders/ImagesLoader.swift
@@ -204,13 +204,3 @@ private extension String {
     }
 
 }
-
-// MARK: - Array Utils
-
-private extension Array {
-    func chunked(into size: Int) -> [[Element]] {
-        stride(from: 0, to: count, by: size).map {
-            Array(self[$0 ..< Swift.min($0 + size, count)])
-        }
-    }
-}

--- a/Sources/FigmaExport/Output/FileDownloader.swift
+++ b/Sources/FigmaExport/Output/FileDownloader.swift
@@ -19,11 +19,11 @@ final class FileDownloader {
         let remoteFileCount = files.filter { $0.sourceURL != nil }.count
         var downloaded = 0
 
-        let chankedFiles = files.chunked(
+        let chunkedFiles = files.chunked(
             into: session.configuration.httpMaximumConnectionsPerHost
         )
 
-        chankedFiles.forEach { filesBatch in
+        chunkedFiles.forEach { filesBatch in
             let group = DispatchGroup()
 
             filesBatch.forEach { file in

--- a/Sources/FigmaExport/Output/FileDownloader.swift
+++ b/Sources/FigmaExport/Output/FileDownloader.swift
@@ -20,7 +20,7 @@ final class FileDownloader {
         let remoteFileCount = files.filter { $0.sourceURL != nil }.count
         var downloaded = 0
 
-        let semaphore = DispatchSemaphore(value: session.configuration.httpMaximumConnectionsPerHost)
+        let semaphore = DispatchSemaphore(value: session.configuration.httpMaximumConnectionsPerHost - 1)
 
         files.forEach { file in
             guard let remoteURL = file.sourceURL else {

--- a/Sources/FigmaExportCore/Extensions/Array+chunked.swift
+++ b/Sources/FigmaExportCore/Extensions/Array+chunked.swift
@@ -1,10 +1,3 @@
-//
-//  File.swift
-//  
-//
-//  Created by i.kharabet on 19.02.2021.
-//
-
 import Foundation
 
 public extension Array {

--- a/Sources/FigmaExportCore/Extensions/Array+chunked.swift
+++ b/Sources/FigmaExportCore/Extensions/Array+chunked.swift
@@ -1,0 +1,16 @@
+//
+//  File.swift
+//  
+//
+//  Created by i.kharabet on 19.02.2021.
+//
+
+import Foundation
+
+public extension Array {
+    func chunked(into size: Int) -> [[Element]] {
+        stride(from: 0, to: count, by: size).map {
+            Array(self[$0 ..< Swift.min($0 + size, count)])
+        }
+    }
+}


### PR DESCRIPTION
I've found an issue with fetching asset files – if there are many files in a frame, you get the `Request timed out` error after 60 seconds of downloading.

This happens because all file download requests add in a URLSession at the same moment. URLSession has a maximum simultaneous requests count and all requests after this count wait in the queue. And when this is their turn to execute, they have already timed out.

I solved this problem by chunking requests in `FileDownloader`.