### PR TITLE
Allow TextStyle to be processable by an AssetsProcessor

### DIFF
--- a/CONFIG.md
+++ b/CONFIG.md
@@ -46,6 +46,12 @@ common:
     nameValidateRegexp: '^(img)_([a-z0-9_]+)$' # RegExp pattern for: img_image_name
     # [optional] RegExp pattern for replacing. Supports only $n
     nameReplaceRegexp: 'image_$2'
+  # [optional]
+  typography:
+    # [optional] RegExp pattern for text style name validation before exporting
+    nameValidateRegexp: '^[a-zA-Z0-9_]+$' # RegExp pattern for: h1_regular, h1_medium
+    # [optional] RegExp pattern for replacing. Supports only $n
+    nameReplaceRegexp: 'font_$1'
 
 # [optional] iOS export parameters
 ios:
@@ -116,6 +122,8 @@ ios:
     generateLabels: true
     # Relative or absolute path to directory where to place UILabel for each text style (font) (Requred if generateLabels = true)
     labelsDirectory: "./Source/UIComponents/"
+    # Typography name style: camelCase or snake_case
+    nameStyle: camelCase
 
 # [optional] Android export parameters
 android:

--- a/Sources/FigmaExport/Input/Params.swift
+++ b/Sources/FigmaExport/Input/Params.swift
@@ -31,9 +31,15 @@ struct Params: Decodable {
             let nameReplaceRegexp: String?
         }
 
+        struct Typography: Decodable {
+            let nameValidateRegexp: String?
+            let nameReplaceRegexp: String?
+        }
+
         let colors: Colors?
         let icons: Icons?
         let images: Images?
+        let typography: Typography?
     }
 
     enum VectorFormat: String, Decodable {
@@ -78,8 +84,6 @@ struct Params: Decodable {
             let swiftUIFontSwift: URL?
             let generateLabels: Bool
             let labelsDirectory: URL?
-            let nameValidateRegexp: String?
-            let nameReplaceRegexp: String?
             let nameStyle: NameStyle
         }
 

--- a/Sources/FigmaExport/Input/Params.swift
+++ b/Sources/FigmaExport/Input/Params.swift
@@ -78,6 +78,9 @@ struct Params: Decodable {
             let swiftUIFontSwift: URL?
             let generateLabels: Bool
             let labelsDirectory: URL?
+            let nameValidateRegexp: String?
+            let nameReplaceRegexp: String?
+            let nameStyle: NameStyle
         }
 
         let xcodeprojPath: String

--- a/Sources/FigmaExport/Subcommands/ExportTypography.swift
+++ b/Sources/FigmaExport/Subcommands/ExportTypography.swift
@@ -29,8 +29,16 @@ extension FigmaExportCommand {
             let textStyles = try loader.load()
 
             if let ios = options.params.ios {
+                logger.info("Processing typography...")
+                let processor = TypographyProcessor(
+                    platform: .ios,
+                    nameValidateRegexp: options.params.ios?.typography.nameValidateRegexp,
+                    nameReplaceRegexp: options.params.ios?.typography.nameReplaceRegexp,
+                    nameStyle: options.params.ios?.typography.nameStyle
+                )
+                let processedTextStyles = try processor.process(assets: textStyles).get()
                 logger.info("Saving text styles...")
-                try exportXcodeTextStyles(textStyles: textStyles, iosParams: ios, logger: logger)
+                try exportXcodeTextStyles(textStyles: processedTextStyles, iosParams: ios, logger: logger)
                 logger.info("Done!")
             }
         }

--- a/Sources/FigmaExport/Subcommands/ExportTypography.swift
+++ b/Sources/FigmaExport/Subcommands/ExportTypography.swift
@@ -32,8 +32,8 @@ extension FigmaExportCommand {
                 logger.info("Processing typography...")
                 let processor = TypographyProcessor(
                     platform: .ios,
-                    nameValidateRegexp: options.params.ios?.typography.nameValidateRegexp,
-                    nameReplaceRegexp: options.params.ios?.typography.nameReplaceRegexp,
+                    nameValidateRegexp: options.params.common?.typography?.nameValidateRegexp,
+                    nameReplaceRegexp: options.params.common?.typography?.nameReplaceRegexp,
                     nameStyle: options.params.ios?.typography.nameStyle
                 )
                 let processedTextStyles = try processor.process(assets: textStyles).get()

--- a/Sources/FigmaExportCore/Processor/AssetsProcessor.swift
+++ b/Sources/FigmaExportCore/Processor/AssetsProcessor.swift
@@ -60,6 +60,22 @@ public struct ColorsProcessor: AssetsProcessable {
     }
 }
 
+public struct TypographyProcessor: AssetsProcessable {
+    public typealias AssetType = TextStyle
+
+    public let platform: Platform
+    public let nameValidateRegexp: String?
+    public let nameReplaceRegexp: String?
+    public let nameStyle: NameStyle?
+
+    public init(platform: Platform, nameValidateRegexp: String?, nameReplaceRegexp: String?, nameStyle: NameStyle?) {
+        self.platform = platform
+        self.nameValidateRegexp = nameValidateRegexp
+        self.nameReplaceRegexp = nameReplaceRegexp
+        self.nameStyle = nameStyle
+    }
+}
+
 public struct ImagesProcessor: AssetsProcessable {
     public typealias AssetType = ImagePack
 

--- a/Sources/FigmaExportCore/TextStyle.swift
+++ b/Sources/FigmaExportCore/TextStyle.swift
@@ -39,9 +39,9 @@ public enum DynamicTypeStyle: String, RawRepresentable {
     }
 }
 
-public struct TextStyle {
-    
-    public let name: String
+public struct TextStyle: Asset {
+    public var name: String
+    public var platform: Platform?
     public let fontName: String
     public let fontSize: Double
     public let fontStyle: DynamicTypeStyle?
@@ -50,6 +50,7 @@ public struct TextStyle {
 
     public init(
         name: String,
+        platform: Platform? = nil,
         fontName: String,
         fontSize: Double,
         fontStyle: DynamicTypeStyle?,
@@ -62,5 +63,15 @@ public struct TextStyle {
         self.fontStyle = fontStyle
         self.lineHeight = lineHeight
         self.letterSpacing = letterSpacing
+    }
+
+    // MARK: Hashable
+
+    public static func == (lhs: TextStyle, rhs: TextStyle) -> Bool {
+        return lhs.name == rhs.name
+    }
+
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(name)
     }
 }


### PR DESCRIPTION
## Description

As mentioned in #77, exporting text styles contained in folders results in invalid names when generating Swift and SwiftUI code. Text styles should allow the same type of configuration for their names as color styles. 

## Changes

- Added params to the yaml file, similar to color styles
  -  `nameValidateRegexp`
  - `nameReplaceRegexp`
  - `nameStyle`
- Added `TypographyProcessor`
- Process text styles in `ExportTypography`, similar to `ExportColors`
- Added conformance for `Asset` to `TextStyle`

Fixes #77 