### PR TITLE
Added scales param for Android images export

### DIFF
--- a/CONFIG.md
+++ b/CONFIG.md
@@ -134,6 +134,8 @@ android:
     # Image file format: svg or png
     format: webp
     # Format options for webp format only
+    # [optional] An array of asset scales that should be downloaded. The valid values are 1 (mdpi), 1.5 (hdpi), 2 (xhdpi), 3 (xxhdpi), 4 (xxxhdpi). The deafault value is [1, 1.5, 2, 3, 4].
+    scales: [1, 2, 3]
     webpOptions:
       # Encoding type: lossy or lossless
       encoding: lossy

--- a/Sources/AndroidExport/Drawable.swift
+++ b/Sources/AndroidExport/Drawable.swift
@@ -1,6 +1,9 @@
 public enum Drawable {
     
-    public static func scaleToDrawableName(_ scale: Double, dark: Bool) -> String {
+    public static func scaleToDrawableName(_ scale: Double, dark: Bool, singleScale: Bool) -> String {
+        if singleScale {
+            return dark ? "drawable-night" : "drawable"
+        }
         switch scale {
         case 1:
             return dark ? "drawable-night-mdpi" : "drawable-mdpi"

--- a/Sources/FigmaExport/Input/Params.swift
+++ b/Sources/FigmaExport/Input/Params.swift
@@ -116,6 +116,7 @@ struct Params: Decodable {
                 let encoding: Encoding
                 let quality: Int?
             }
+            let scales: [Double]?
             let output: String
             let format: Format
             let webpOptions: FormatOptions?

--- a/Sources/FigmaExport/Loaders/ImagesLoader.swift
+++ b/Sources/FigmaExport/Loaders/ImagesLoader.swift
@@ -166,13 +166,19 @@ final class ImagesLoader {
     }
 
     private func getScales(platform: Platform) -> [Double] {
-        if platform == .android {
-            return [1, 2, 3, 1.5, 4.0]
-        } else {
-            let validScales: [Double] = [1, 2, 3]
-            let customScales = params.ios?.images.scales?.filter { validScales.contains($0) } ?? []
-            return customScales.isEmpty ? validScales : customScales
+        var validScales: [Double] = []
+        var customScales: [Double] = []
+        let filterScales = { (platformScales: [Double]?) -> [Double] in
+            platformScales?.filter { validScales.contains($0) } ?? []
         }
+        if platform == .android {
+            validScales = [1, 2, 3, 1.5, 4.0]
+            customScales = filterScales(params.android?.images?.scales)
+        } else {
+            validScales = [1, 2, 3]
+            customScales = filterScales(params.ios?.images.scales)
+        }
+        return customScales.isEmpty ? validScales : customScales
     }
 
     // MARK: - Figma

--- a/Sources/FigmaExport/Subcommands/ExportImages.swift
+++ b/Sources/FigmaExport/Subcommands/ExportImages.swift
@@ -268,8 +268,13 @@ extension FigmaExportCommand {
             logger.info("Writting files to Android Studio project...")
             
             // Move PNG/WebP files to main/res/figma-export-images/drawable-XXXdpi/
+            let isSingleScale = params.android?.images?.scales?.count == 1
             localFiles = localFiles.map { fileContents -> FileContents in
-                let directoryName = Drawable.scaleToDrawableName(fileContents.scale, dark: fileContents.dark)
+                let directoryName = Drawable.scaleToDrawableName(
+                    fileContents.scale,
+                    dark: fileContents.dark,
+                    singleScale: isSingleScale
+                )
                 let directory = URL(fileURLWithPath: android.mainRes.appendingPathComponent(androidImages.output).path)
                     .appendingPathComponent(directoryName, isDirectory: true)
                 return FileContents(


### PR DESCRIPTION
Not in all cases you need to export images in 5 scales, now it is possible to specify custom scales but this option is only available for ios params. I added the scales parameter for android params