### PR TITLE
Add shell bash to GitHub action test

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,3 +22,4 @@ jobs:
         run: sudo xcode-select --switch /Applications/Xcode_12.app
       - name: Build and test
         run: swift test --enable-code-coverage --disable-automatic-resolution
+      - shell: bash


### PR DESCRIPTION
`shell: bash` adds flags to handle exit codes with errors