### PR TITLE
Support exporting icons/images from a single figma file

### DIFF
--- a/CONFIG.md
+++ b/CONFIG.md
@@ -38,6 +38,10 @@ common:
     nameValidateRegexp: '^(ic)_(\d\d)_([a-z0-9_]+)$' # RegExp pattern for: ic_24_icon_name, ic_24_icon
     # [optional] RegExp pattern for replacing. Supports only $n
     nameReplaceRegexp: 'icon_$2_$1'
+    # [optional] Extract light and dark mode icons from the lightFileId specified in the figma params. Defaults to false
+    useSingleFile: true
+    # [optional] If useSingleFile is true, customize the suffix to denote a dark mode icons. Defaults to '_dark'
+    darkModeSuffix: '_dark'
   # [optional]
   images:
     # [optional]Name of the Figma's frame where image components are located
@@ -46,6 +50,10 @@ common:
     nameValidateRegexp: '^(img)_([a-z0-9_]+)$' # RegExp pattern for: img_image_name
     # [optional] RegExp pattern for replacing. Supports only $n
     nameReplaceRegexp: 'image_$2'
+    # [optional] Extract light and dark mode icons from the lightFileId specified in the figma params. Defaults to false
+    useSingleFile: true
+    # [optional] If useSingleFile is true, customize the suffix to denote a dark mode icons. Defaults to '_dark'
+    darkModeSuffix: '_dark'
   # [optional]
   typography:
     # [optional] RegExp pattern for text style name validation before exporting

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 Command line utility to export colors, typography, icons and images from Figma to Xcode / Android Studio project.
 * color - Figma's color style
 * typography - Figma's text style
-* icon — Figma's component with small black vector image
+* icon — Figma's component with small black/colors vector image
 * image — Figma's components with colorized image (Light/Dark)
 
 The utility supports Dark Mode and SwiftUI.
@@ -380,12 +380,13 @@ File | Styles
 For `figma-export icons`
 
 By default your Figma file should contains a frame with `Icons` name which contains components for each icon. You may change a frame name in a [config](Config.md) file by setting `common.icons.figmaFrameName` property.
+If you support dark mode your figma project must contains two files. One should contains a dark icons, and the another light icons. If you would like to specify light and dark icons in the same file, you can do so with the `useSingleFile` configuration option. You can then denote dark mode icons by adding a suffix like `_dark`. The suffix is also configurable. See [config](Config.md) for more information in the icons section.
 
 For `figma-export images`
 
 Your Figma file should contains a frame with `Illustrations` name which contains components for each illustration. You may change a frame name in a [config](Config.md) file by setting `common.images.figmaFrameName` property.
 
-If you support dark mode you must have two Figma files. The rules for these two files follow the same rules as described above for colors.
+If you support dark mode you must have two Figma files. The rules for these two files follow the same rules as described above for colors. But If you would like to specify light and dark illustrations in the same file, you can do so with the `useSingleFile` configuration option. You can then denote dark mode illustrations by adding a suffix like `_dark`. The suffix is also configurable. See [config](Config.md) for more information in the illustrations section.
 
 If you want to specify image variants for different devices (iPhone, iPad, Mac etc.), add an extra `~` mark with idiom name. For example add `~ipad` postfix:
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 Command line utility to export colors, typography, icons and images from Figma to Xcode / Android Studio project.
 * color - Figma's color style
 * typography - Figma's text style
-* icon — Figma's component with small black/colors vector image
+* icon — Figma's component with small black/colorized vector image
 * image — Figma's components with colorized image (Light/Dark)
 
 The utility supports Dark Mode and SwiftUI.
@@ -380,7 +380,7 @@ File | Styles
 For `figma-export icons`
 
 By default your Figma file should contains a frame with `Icons` name which contains components for each icon. You may change a frame name in a [config](Config.md) file by setting `common.icons.figmaFrameName` property.
-If you support dark mode your figma project must contains two files. One should contains a dark icons, and the another light icons. If you would like to specify light and dark icons in the same file, you can do so with the `useSingleFile` configuration option. You can then denote dark mode icons by adding a suffix like `_dark`. The suffix is also configurable. See [config](Config.md) for more information in the icons section.
+If you support dark mode and want separate icons for dark mode, Figma project must contains two files. One should contains a dark icons, and another light icons. If you would like to have light and dark icons in the same file, you can do so with the `useSingleFile` configuration option. You can then denote dark mode icons by adding a suffix like `_dark`. The suffix is also configurable. See [config](Config.md) for more information in the icons section.
 
 For `figma-export images`
 

--- a/Sources/FigmaExport/Input/Params.swift
+++ b/Sources/FigmaExport/Input/Params.swift
@@ -23,12 +23,16 @@ struct Params: Decodable {
             let nameValidateRegexp: String?
             let figmaFrameName: String?
             let nameReplaceRegexp: String?
+            let useSingleFile: Bool?
+            let darkModeSuffix: String?
         }
 
         struct Images: Decodable {
             let nameValidateRegexp: String?
             let figmaFrameName: String?
             let nameReplaceRegexp: String?
+            let useSingleFile: Bool?
+            let darkModeSuffix: String?
         }
 
         struct Typography: Decodable {

--- a/Sources/FigmaExport/Loaders/ImagesLoader.swift
+++ b/Sources/FigmaExport/Loaders/ImagesLoader.swift
@@ -79,8 +79,8 @@ final class ImagesLoader {
             params: formatParams,
             filter: filter
         )
-        let darkIcons = try? params.figma.darkFileId.map {
-            try _loadImages(
+        let darkIcons = params.figma.darkFileId.flatMap {
+            try? _loadImages(
                 fileId: $0,
                 frameName: iconsFrameName,
                 params: formatParams,
@@ -133,8 +133,8 @@ final class ImagesLoader {
                 frameName: imagesFrameName,
                 filter: filter,
                 platform: platform)
-            let darkImages = try? params.figma.darkFileId.map {
-                try loadPNGImages(
+            let darkImages = params.figma.darkFileId.flatMap {
+                try? loadPNGImages(
                     fileId: $0,
                     frameName: imagesFrameName,
                     filter: filter,
@@ -151,8 +151,8 @@ final class ImagesLoader {
                 params: SVGParams(),
                 filter: filter)
 
-            let darkPacks = try? params.figma.darkFileId.map {
-                try _loadImages(
+            let darkPacks = params.figma.darkFileId.flatMap {
+                try? _loadImages(
                     fileId: $0,
                     frameName: imagesFrameName,
                     params: SVGParams(),

--- a/Sources/FigmaExport/Loaders/ImagesLoader.swift
+++ b/Sources/FigmaExport/Loaders/ImagesLoader.swift
@@ -27,7 +27,7 @@ final class ImagesLoader {
     }
 
     func loadIcons(filter: String? = nil) throws -> (light: [ImagePack], dark: [ImagePack]?) {
-        if params.common?.icons?.useSingleFile == true {
+        if let useSingleFile = params.common?.icons?.useSingleFile, useSingleFile {
             return try loadIconsFromSingleFile(filter: filter)
         } else {
             return try loadIconsFromLightAndDarkFile(filter: filter)
@@ -90,7 +90,7 @@ final class ImagesLoader {
     }
 
     func loadImages(filter: String? = nil) throws -> (light: [ImagePack], dark: [ImagePack]?) {
-        if params.common?.images?.useSingleFile == true {
+        if let useSingleFile = params.common?.images?.useSingleFile, useSingleFile {
             return try loadImagesFromSingleFile(filter: filter)
         } else {
             return try loadImagesFromLightAndDarkFile(filter: filter)

--- a/Sources/FigmaExport/Loaders/ImagesLoader.swift
+++ b/Sources/FigmaExport/Loaders/ImagesLoader.swift
@@ -55,6 +55,11 @@ final class ImagesLoader {
             .filter { !$0.name.hasSuffix(darkSuffix) }
         let darkIcons = icons
             .filter { $0.name.hasSuffix(darkSuffix) }
+            .map { icon -> ImagePack in
+                var newIcon = icon
+                newIcon.name = String(icon.name.dropLast(darkSuffix.count))
+                return newIcon
+            }
         return (lightIcons, darkIcons)
     }
 

--- a/Sources/FigmaExport/Loaders/ImagesLoader.swift
+++ b/Sources/FigmaExport/Loaders/ImagesLoader.swift
@@ -79,7 +79,7 @@ final class ImagesLoader {
             params: formatParams,
             filter: filter
         )
-        let darkIcons = try params.figma.darkFileId.map {
+        let darkIcons = try? params.figma.darkFileId.map {
             try _loadImages(
                 fileId: $0,
                 frameName: iconsFrameName,
@@ -133,7 +133,7 @@ final class ImagesLoader {
                 frameName: imagesFrameName,
                 filter: filter,
                 platform: platform)
-            let darkImages = try params.figma.darkFileId.map {
+            let darkImages = try? params.figma.darkFileId.map {
                 try loadPNGImages(
                     fileId: $0,
                     frameName: imagesFrameName,
@@ -151,7 +151,7 @@ final class ImagesLoader {
                 params: SVGParams(),
                 filter: filter)
 
-            let darkPacks = try params.figma.darkFileId.map {
+            let darkPacks = try? params.figma.darkFileId.map {
                 try _loadImages(
                     fileId: $0,
                     frameName: imagesFrameName,

--- a/Sources/FigmaExport/Loaders/ImagesLoader.swift
+++ b/Sources/FigmaExport/Loaders/ImagesLoader.swift
@@ -27,7 +27,7 @@ final class ImagesLoader {
     }
 
     func loadIcons(filter: String? = nil) throws -> (light: [ImagePack], dark: [ImagePack]?) {
-        if let useSingleFile = params.common?.icons?.useSingleFile, useSingleFile {
+        if params.common?.icons?.useSingleFile == true {
             return try loadIconsFromSingleFile(filter: filter)
         } else {
             return try loadIconsFromLightAndDarkFile(filter: filter)
@@ -90,7 +90,7 @@ final class ImagesLoader {
     }
 
     func loadImages(filter: String? = nil) throws -> (light: [ImagePack], dark: [ImagePack]?) {
-        if let useSingleFile = params.common?.images?.useSingleFile, useSingleFile {
+        if params.common?.images?.useSingleFile == true {
             return try loadImagesFromSingleFile(filter: filter)
         } else {
             return try loadImagesFromLightAndDarkFile(filter: filter)

--- a/Sources/FigmaExport/Resources/iOSConfig.swift
+++ b/Sources/FigmaExport/Resources/iOSConfig.swift
@@ -58,7 +58,7 @@ ios:
     assetsFolder: Icons
     # Icon name style: camelCase or snake_case
     nameStyle: camelCase
-    # [optional] An array of icon names that will supports Preseve Vecotor Data
+    # [optional] An array of icon names that will supports Preserve Vector Data
     preservesVectorRepresentation:
     - ic24TabBarMain
     - ic24TabBarEvents

--- a/Sources/FigmaExport/Subcommands/ExportIcons.swift
+++ b/Sources/FigmaExport/Subcommands/ExportIcons.swift
@@ -60,9 +60,6 @@ extension FigmaExportCommand {
             )
 
             let icons = processor.process(light: imagesTuple.light, dark: imagesTuple.dark)
-            if let warning = icons.warning?.errorDescription {
-                logger.warning("\(warning)")
-            }
 
             let assetsURL = ios.xcassetsPath.appendingPathComponent(iconsParams.assetsFolder)
 
@@ -77,7 +74,7 @@ extension FigmaExportCommand {
                 renderMode: iconsParams.renderMode)
             
             let exporter = XcodeIconsExporter(output: output)
-            let localAndRemoteFiles = try exporter.export(icons: icons, append: filter != nil)
+            let localAndRemoteFiles = try exporter.export(icons: icons.get(), append: filter != nil)
             if filter == nil {
                 try? FileManager.default.removeItem(atPath: assetsURL.path)
             }
@@ -125,10 +122,7 @@ extension FigmaExportCommand {
                 nameStyle: .snakeCase
             )
 
-            let icons = processor.process(light: imagesTuple.light, dark: imagesTuple.dark).get()
-            if let warning = icons.warning?.errorDescription {
-                logger.warning("\(warning)")
-            }
+            let icons = try processor.process(light: imagesTuple.light, dark: imagesTuple.dark).get()
             
             // Create empty temp directory
             let tempDirectoryLightURL = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)

--- a/Sources/XcodeExport/Model/XcodeExportExtensions.swift
+++ b/Sources/XcodeExport/Model/XcodeExportExtensions.swift
@@ -115,14 +115,23 @@ extension AssetPair where AssetType == ImagePack {
         let name = light.name
         let dirURL = directory.appendingPathComponent("\(name).imageset")
 
+        var lightAssetContents: [XcodeAssetContents.ImageData] = []
+        var darkAssetContents: [XcodeAssetContents.ImageData] = []
+        var lightFiles: [FileContents] = []
+        var darkFiles: [FileContents] = []
+
         let lightPack = light.packForXcode()
         let darkPack = dark?.packForXcode()
 
-        let lightFiles = lightPack?.makeImageFileContents(to: dirURL, appearance: .light) ?? []
-        let darkFiles = darkPack?.makeImageFileContents(to: dirURL, appearance: .dark) ?? []
-
-        let lightAssetContents = lightPack?.makeXcodeAssetContentsImageData(appearance: .light) ?? []
-        let darkAssetContents = darkPack?.makeXcodeAssetContentsImageData(appearance: .dark) ?? []
+        if darkPack != nil {
+            lightAssetContents = lightPack?.makeXcodeAssetContentsImageData(appearance: .light) ?? []
+            darkAssetContents = darkPack?.makeXcodeAssetContentsImageData(appearance: .dark) ?? []
+            lightFiles = lightPack?.makeImageFileContents(to: dirURL, appearance: .light) ?? []
+            darkFiles = darkPack?.makeImageFileContents(to: dirURL, appearance: .dark) ?? []
+        } else {
+            lightAssetContents = lightPack?.makeXcodeAssetContentsImageData() ?? []
+            lightFiles = lightPack?.makeImageFileContents(to: dirURL) ?? []
+        }
 
         let properties = XcodeAssetContents.Properties(preserveVectorData: preservesVector, renderMode: renderMode)
 

--- a/Sources/XcodeExport/XcodeIconsExporter.swift
+++ b/Sources/XcodeExport/XcodeIconsExporter.swift
@@ -3,7 +3,7 @@ import FigmaExportCore
 
 final public class XcodeIconsExporter: XcodeImagesExporterBase {
 
-    public func export(icons: [ImagePack], append: Bool) throws -> [FileContents] {
+    public func export(icons: [AssetPair<ImagePack>], append: Bool) throws -> [FileContents] {
         // Generate metadata (Assets.xcassets/Icons/Contents.json)
         let contentsFile = XcodeEmptyContents().makeFileContents(to: output.assetsFolderURL)
 
@@ -13,15 +13,15 @@ final public class XcodeIconsExporter: XcodeImagesExporterBase {
         let renderMode = output.renderMode ?? .template
 
         let imageAssetsFiles = try icons.flatMap { imagePack -> [FileContents] in
-            let preservesVector = preservesVectorRepresentation?.first(where: { $0 == imagePack.name }) != nil
+            let preservesVector = preservesVectorRepresentation?.first(where: { $0 == imagePack.light.name }) != nil
             return try imagePack.makeFileContents(to: assetsFolderURL, preservesVector: preservesVector, renderMode: renderMode)
         }
 
         // Generate extensions
-        let imageNames = icons.map { $0.name }
+        let imageNames = icons.map { $0.light.name }
         let extensionFiles = try generateExtensions(names: imageNames, append: append)
 
         return [contentsFile] + imageAssetsFiles + extensionFiles
     }
-    
+
 }

--- a/Tests/XcodeExportTests/XcodeIconsExporterTests.swift
+++ b/Tests/XcodeExportTests/XcodeIconsExporterTests.swift
@@ -4,7 +4,7 @@ import FigmaExportCore
 @testable import XcodeExport
 
 final class XcodeIconsExporterTests: XCTestCase {
-    
+
     // MARK: - Properties
 
     private let image1 = Image(name: "image1", url: URL(string: "1")!, format: "pdf")
@@ -18,21 +18,21 @@ final class XcodeIconsExporterTests: XCTestCase {
         .appendingPathComponent("Image+extension.swift")
 
     // MARK: - Tests
-    
+
     func testExport() throws {
         let output = XcodeImagesOutput(assetsFolderURL: URL(string: "~/")!, assetsInMainBundle: true, uiKitImageExtensionURL: uiKitImageExtensionURL)
         let exporter = XcodeIconsExporter(output: output)
         let result = try exporter.export(
-            icons: [ImagePack(image: image1), ImagePack(image: image2)],
+            icons: [AssetPair(light: ImagePack(image: image1), dark: nil), AssetPair(light: ImagePack(image: image2), dark: nil)],
             append: false
         )
-        
+
         XCTAssertEqual(result.count, 6)
         XCTAssertTrue(result[0].destination.url.absoluteString.hasSuffix("Contents.json"))
-        XCTAssertTrue(result[1].destination.url.absoluteString.hasSuffix("image1.imageset/image1.pdf"))
-        XCTAssertTrue(result[2].destination.url.absoluteString.hasSuffix("image1.imageset/Contents.json"))
-        XCTAssertTrue(result[3].destination.url.absoluteString.hasSuffix("image2.imageset/image2.pdf"))
-        XCTAssertTrue(result[4].destination.url.absoluteString.hasSuffix("image2.imageset/Contents.json"))
+        XCTAssertTrue(result[1].destination.url.absoluteString.hasSuffix("image1.imageset/Contents.json"))
+        XCTAssertTrue(result[2].destination.url.absoluteString.hasSuffix("image1.imageset/image1L.pdf"))
+        XCTAssertTrue(result[3].destination.url.absoluteString.hasSuffix("image2.imageset/Contents.json"))
+        XCTAssertTrue(result[4].destination.url.absoluteString.hasSuffix("image2.imageset/image2L.pdf"))
         XCTAssertTrue(result[5].destination.url.absoluteString.hasSuffix("UIImage+extension.swift"))
 
         let content = result[5].data
@@ -62,16 +62,16 @@ final class XcodeIconsExporterTests: XCTestCase {
         )
         let exporter = XcodeIconsExporter(output: output)
         let result = try exporter.export(
-            icons: [ImagePack(image: image1), ImagePack(image: image2)],
+            icons: [AssetPair(light: ImagePack(image: image1), dark: nil), AssetPair(light: ImagePack(image: image2), dark: nil)],
             append: false
         )
 
         XCTAssertEqual(result.count, 6)
         XCTAssertTrue(result[0].destination.url.absoluteString.hasSuffix("Contents.json"))
-        XCTAssertTrue(result[1].destination.url.absoluteString.hasSuffix("image1.imageset/image1.pdf"))
-        XCTAssertTrue(result[2].destination.url.absoluteString.hasSuffix("image1.imageset/Contents.json"))
-        XCTAssertTrue(result[3].destination.url.absoluteString.hasSuffix("image2.imageset/image2.pdf"))
-        XCTAssertTrue(result[4].destination.url.absoluteString.hasSuffix("image2.imageset/Contents.json"))
+        XCTAssertTrue(result[1].destination.url.absoluteString.hasSuffix("image1.imageset/Contents.json"))
+        XCTAssertTrue(result[2].destination.url.absoluteString.hasSuffix("image1.imageset/image1L.pdf"))
+        XCTAssertTrue(result[3].destination.url.absoluteString.hasSuffix("image2.imageset/Contents.json"))
+        XCTAssertTrue(result[4].destination.url.absoluteString.hasSuffix("image2.imageset/image2L.pdf"))
         XCTAssertTrue(result[5].destination.url.absoluteString.hasSuffix("UIImage+extension.swift"))
 
         let content = result[5].data
@@ -91,21 +91,21 @@ final class XcodeIconsExporterTests: XCTestCase {
         """
         XCTAssertEqual(generatedCode, referenceCode)
     }
-    
+
     func testExportInSeparateBundle() throws {
         let output = XcodeImagesOutput(assetsFolderURL: URL(string: "~/")!, assetsInMainBundle: false, assetsInSwiftPackage: false, uiKitImageExtensionURL: uiKitImageExtensionURL)
         let exporter = XcodeIconsExporter(output: output)
         let result = try exporter.export(
-            icons: [ImagePack(image: image1), ImagePack(image: image2)],
+            icons: [AssetPair(light: ImagePack(image: image1), dark: nil), AssetPair(light: ImagePack(image: image2), dark: nil)],
             append: false
         )
-        
+
         XCTAssertEqual(result.count, 6)
         XCTAssertTrue(result[0].destination.url.absoluteString.hasSuffix("Contents.json"))
-        XCTAssertTrue(result[1].destination.url.absoluteString.hasSuffix("image1.imageset/image1.pdf"))
-        XCTAssertTrue(result[2].destination.url.absoluteString.hasSuffix("image1.imageset/Contents.json"))
-        XCTAssertTrue(result[3].destination.url.absoluteString.hasSuffix("image2.imageset/image2.pdf"))
-        XCTAssertTrue(result[4].destination.url.absoluteString.hasSuffix("image2.imageset/Contents.json"))
+        XCTAssertTrue(result[1].destination.url.absoluteString.hasSuffix("image1.imageset/Contents.json"))
+        XCTAssertTrue(result[2].destination.url.absoluteString.hasSuffix("image1.imageset/image1L.pdf"))
+        XCTAssertTrue(result[3].destination.url.absoluteString.hasSuffix("image2.imageset/Contents.json"))
+        XCTAssertTrue(result[4].destination.url.absoluteString.hasSuffix("image2.imageset/image2L.pdf"))
         XCTAssertTrue(result[5].destination.url.absoluteString.hasSuffix("UIImage+extension.swift"))
 
         let content = result[5].data
@@ -134,16 +134,16 @@ final class XcodeIconsExporterTests: XCTestCase {
         let output = XcodeImagesOutput(assetsFolderURL: URL(string: "~/")!, assetsInMainBundle: false, assetsInSwiftPackage: true, uiKitImageExtensionURL: uiKitImageExtensionURL)
         let exporter = XcodeIconsExporter(output: output)
         let result = try exporter.export(
-            icons: [ImagePack(image: image1), ImagePack(image: image2)],
+            icons: [AssetPair(light: ImagePack(image: image1), dark: nil), AssetPair(light: ImagePack(image: image2), dark: nil)],
             append: false
         )
 
         XCTAssertEqual(result.count, 6)
         XCTAssertTrue(result[0].destination.url.absoluteString.hasSuffix("Contents.json"))
-        XCTAssertTrue(result[1].destination.url.absoluteString.hasSuffix("image1.imageset/image1.pdf"))
-        XCTAssertTrue(result[2].destination.url.absoluteString.hasSuffix("image1.imageset/Contents.json"))
-        XCTAssertTrue(result[3].destination.url.absoluteString.hasSuffix("image2.imageset/image2.pdf"))
-        XCTAssertTrue(result[4].destination.url.absoluteString.hasSuffix("image2.imageset/Contents.json"))
+        XCTAssertTrue(result[1].destination.url.absoluteString.hasSuffix("image1.imageset/Contents.json"))
+        XCTAssertTrue(result[2].destination.url.absoluteString.hasSuffix("image1.imageset/image1L.pdf"))
+        XCTAssertTrue(result[3].destination.url.absoluteString.hasSuffix("image2.imageset/Contents.json"))
+        XCTAssertTrue(result[4].destination.url.absoluteString.hasSuffix("image2.imageset/image2L.pdf"))
         XCTAssertTrue(result[5].destination.url.absoluteString.hasSuffix("UIImage+extension.swift"))
 
         let content = result[5].data
@@ -167,21 +167,21 @@ final class XcodeIconsExporterTests: XCTestCase {
         """
         XCTAssertEqual(generatedCode, referenceCode)
     }
-    
+
     func testExportSwiftUI() throws {
         let output = XcodeImagesOutput(assetsFolderURL: URL(string: "~/")!, assetsInMainBundle: true, swiftUIImageExtensionURL: swiftUIImageExtensionURL)
         let exporter = XcodeIconsExporter(output: output)
         let result = try exporter.export(
-            icons: [ImagePack(image: image1), ImagePack(image: image2)],
+            icons: [AssetPair(light: ImagePack(image: image1), dark: nil), AssetPair(light: ImagePack(image: image2), dark: nil)],
             append: false
         )
 
         XCTAssertEqual(result.count, 6)
         XCTAssertTrue(result[0].destination.url.absoluteString.hasSuffix("Contents.json"))
-        XCTAssertTrue(result[1].destination.url.absoluteString.hasSuffix("image1.imageset/image1.pdf"))
-        XCTAssertTrue(result[2].destination.url.absoluteString.hasSuffix("image1.imageset/Contents.json"))
-        XCTAssertTrue(result[3].destination.url.absoluteString.hasSuffix("image2.imageset/image2.pdf"))
-        XCTAssertTrue(result[4].destination.url.absoluteString.hasSuffix("image2.imageset/Contents.json"))
+        XCTAssertTrue(result[1].destination.url.absoluteString.hasSuffix("image1.imageset/Contents.json"))
+        XCTAssertTrue(result[2].destination.url.absoluteString.hasSuffix("image1.imageset/image1L.pdf"))
+        XCTAssertTrue(result[3].destination.url.absoluteString.hasSuffix("image2.imageset/Contents.json"))
+        XCTAssertTrue(result[4].destination.url.absoluteString.hasSuffix("image2.imageset/image2L.pdf"))
         XCTAssertTrue(result[5].destination.url.absoluteString.hasSuffix("Image+extension.swift"))
 
         let content = result[5].data
@@ -201,21 +201,21 @@ final class XcodeIconsExporterTests: XCTestCase {
         """
         XCTAssertEqual(generatedCode, referenceCode)
     }
-    
+
     func testExportSwiftUIInSeparateBundle() throws {
         let output = XcodeImagesOutput(assetsFolderURL: URL(string: "~/")!, assetsInMainBundle: false, swiftUIImageExtensionURL: swiftUIImageExtensionURL)
         let exporter = XcodeIconsExporter(output: output)
         let result = try exporter.export(
-            icons: [ImagePack(image: image1), ImagePack(image: image2)],
+            icons: [AssetPair(light: ImagePack(image: image1), dark: nil), AssetPair(light: ImagePack(image: image2), dark: nil)],
             append: false
         )
 
         XCTAssertEqual(result.count, 6)
         XCTAssertTrue(result[0].destination.url.absoluteString.hasSuffix("Contents.json"))
-        XCTAssertTrue(result[1].destination.url.absoluteString.hasSuffix("image1.imageset/image1.pdf"))
-        XCTAssertTrue(result[2].destination.url.absoluteString.hasSuffix("image1.imageset/Contents.json"))
-        XCTAssertTrue(result[3].destination.url.absoluteString.hasSuffix("image2.imageset/image2.pdf"))
-        XCTAssertTrue(result[4].destination.url.absoluteString.hasSuffix("image2.imageset/Contents.json"))
+        XCTAssertTrue(result[1].destination.url.absoluteString.hasSuffix("image1.imageset/Contents.json"))
+        XCTAssertTrue(result[2].destination.url.absoluteString.hasSuffix("image1.imageset/image1L.pdf"))
+        XCTAssertTrue(result[3].destination.url.absoluteString.hasSuffix("image2.imageset/Contents.json"))
+        XCTAssertTrue(result[4].destination.url.absoluteString.hasSuffix("image2.imageset/image2L.pdf"))
         XCTAssertTrue(result[5].destination.url.absoluteString.hasSuffix("Image+extension.swift"))
 
         let content = result[5].data
@@ -248,27 +248,27 @@ final class XcodeIconsExporterTests: XCTestCase {
         )
         let exporter = XcodeIconsExporter(output: output)
         let result = try exporter.export(
-            icons: [ImagePack(image: image1)],
+            icons: [AssetPair(light: ImagePack(image: image1), dark: nil)],
             append: false
         )
 
         XCTAssertEqual(result.count, 4)
         XCTAssertTrue(result[0].destination.url.absoluteString.hasSuffix("Contents.json"))
-        XCTAssertTrue(result[1].destination.url.absoluteString.hasSuffix("image1.imageset/image1.pdf"))
-        XCTAssertTrue(result[2].destination.url.absoluteString.hasSuffix("image1.imageset/Contents.json"))
+        XCTAssertTrue(result[1].destination.url.absoluteString.hasSuffix("image1.imageset/Contents.json"))
+        XCTAssertTrue(result[2].destination.url.absoluteString.hasSuffix("image1.imageset/image1L.pdf"))
         XCTAssertTrue(result[3].destination.url.absoluteString.hasSuffix("UIImage+extension.swift"))
 
         try write(file: result[3])
 
         let appendResult = try exporter.export(
-            icons: [ImagePack(image: image2)],
+            icons: [AssetPair(light: ImagePack(image: image2), dark: nil)],
             append: true
         )
 
         XCTAssertEqual(appendResult.count, 4)
         XCTAssertTrue(appendResult[0].destination.url.absoluteString.hasSuffix("Contents.json"))
-        XCTAssertTrue(appendResult[1].destination.url.absoluteString.hasSuffix("image2.imageset/image2.pdf"))
-
+        XCTAssertTrue(appendResult[1].destination.url.absoluteString.hasSuffix("image2.imageset/Contents.json"))
+        XCTAssertTrue(appendResult[2].destination.url.absoluteString.hasSuffix("image2.imageset/image2L.pdf"))
         let resultContent = try XCTUnwrap(appendResult[3].data)
 
         let generatedCode = String(data: resultContent, encoding: .utf8)

--- a/Tests/XcodeExportTests/XcodeIconsExporterTests.swift
+++ b/Tests/XcodeExportTests/XcodeIconsExporterTests.swift
@@ -30,9 +30,9 @@ final class XcodeIconsExporterTests: XCTestCase {
         XCTAssertEqual(result.count, 6)
         XCTAssertTrue(result[0].destination.url.absoluteString.hasSuffix("Contents.json"))
         XCTAssertTrue(result[1].destination.url.absoluteString.hasSuffix("image1.imageset/Contents.json"))
-        XCTAssertTrue(result[2].destination.url.absoluteString.hasSuffix("image1.imageset/image1L.pdf"))
+        XCTAssertTrue(result[2].destination.url.absoluteString.hasSuffix("image1.imageset/image1.pdf"))
         XCTAssertTrue(result[3].destination.url.absoluteString.hasSuffix("image2.imageset/Contents.json"))
-        XCTAssertTrue(result[4].destination.url.absoluteString.hasSuffix("image2.imageset/image2L.pdf"))
+        XCTAssertTrue(result[4].destination.url.absoluteString.hasSuffix("image2.imageset/image2.pdf"))
         XCTAssertTrue(result[5].destination.url.absoluteString.hasSuffix("UIImage+extension.swift"))
 
         let content = result[5].data
@@ -69,9 +69,9 @@ final class XcodeIconsExporterTests: XCTestCase {
         XCTAssertEqual(result.count, 6)
         XCTAssertTrue(result[0].destination.url.absoluteString.hasSuffix("Contents.json"))
         XCTAssertTrue(result[1].destination.url.absoluteString.hasSuffix("image1.imageset/Contents.json"))
-        XCTAssertTrue(result[2].destination.url.absoluteString.hasSuffix("image1.imageset/image1L.pdf"))
+        XCTAssertTrue(result[2].destination.url.absoluteString.hasSuffix("image1.imageset/image1.pdf"))
         XCTAssertTrue(result[3].destination.url.absoluteString.hasSuffix("image2.imageset/Contents.json"))
-        XCTAssertTrue(result[4].destination.url.absoluteString.hasSuffix("image2.imageset/image2L.pdf"))
+        XCTAssertTrue(result[4].destination.url.absoluteString.hasSuffix("image2.imageset/image2.pdf"))
         XCTAssertTrue(result[5].destination.url.absoluteString.hasSuffix("UIImage+extension.swift"))
 
         let content = result[5].data
@@ -103,9 +103,9 @@ final class XcodeIconsExporterTests: XCTestCase {
         XCTAssertEqual(result.count, 6)
         XCTAssertTrue(result[0].destination.url.absoluteString.hasSuffix("Contents.json"))
         XCTAssertTrue(result[1].destination.url.absoluteString.hasSuffix("image1.imageset/Contents.json"))
-        XCTAssertTrue(result[2].destination.url.absoluteString.hasSuffix("image1.imageset/image1L.pdf"))
+        XCTAssertTrue(result[2].destination.url.absoluteString.hasSuffix("image1.imageset/image1.pdf"))
         XCTAssertTrue(result[3].destination.url.absoluteString.hasSuffix("image2.imageset/Contents.json"))
-        XCTAssertTrue(result[4].destination.url.absoluteString.hasSuffix("image2.imageset/image2L.pdf"))
+        XCTAssertTrue(result[4].destination.url.absoluteString.hasSuffix("image2.imageset/image2.pdf"))
         XCTAssertTrue(result[5].destination.url.absoluteString.hasSuffix("UIImage+extension.swift"))
 
         let content = result[5].data
@@ -141,9 +141,9 @@ final class XcodeIconsExporterTests: XCTestCase {
         XCTAssertEqual(result.count, 6)
         XCTAssertTrue(result[0].destination.url.absoluteString.hasSuffix("Contents.json"))
         XCTAssertTrue(result[1].destination.url.absoluteString.hasSuffix("image1.imageset/Contents.json"))
-        XCTAssertTrue(result[2].destination.url.absoluteString.hasSuffix("image1.imageset/image1L.pdf"))
+        XCTAssertTrue(result[2].destination.url.absoluteString.hasSuffix("image1.imageset/image1.pdf"))
         XCTAssertTrue(result[3].destination.url.absoluteString.hasSuffix("image2.imageset/Contents.json"))
-        XCTAssertTrue(result[4].destination.url.absoluteString.hasSuffix("image2.imageset/image2L.pdf"))
+        XCTAssertTrue(result[4].destination.url.absoluteString.hasSuffix("image2.imageset/image2.pdf"))
         XCTAssertTrue(result[5].destination.url.absoluteString.hasSuffix("UIImage+extension.swift"))
 
         let content = result[5].data
@@ -179,9 +179,9 @@ final class XcodeIconsExporterTests: XCTestCase {
         XCTAssertEqual(result.count, 6)
         XCTAssertTrue(result[0].destination.url.absoluteString.hasSuffix("Contents.json"))
         XCTAssertTrue(result[1].destination.url.absoluteString.hasSuffix("image1.imageset/Contents.json"))
-        XCTAssertTrue(result[2].destination.url.absoluteString.hasSuffix("image1.imageset/image1L.pdf"))
+        XCTAssertTrue(result[2].destination.url.absoluteString.hasSuffix("image1.imageset/image1.pdf"))
         XCTAssertTrue(result[3].destination.url.absoluteString.hasSuffix("image2.imageset/Contents.json"))
-        XCTAssertTrue(result[4].destination.url.absoluteString.hasSuffix("image2.imageset/image2L.pdf"))
+        XCTAssertTrue(result[4].destination.url.absoluteString.hasSuffix("image2.imageset/image2.pdf"))
         XCTAssertTrue(result[5].destination.url.absoluteString.hasSuffix("Image+extension.swift"))
 
         let content = result[5].data
@@ -213,9 +213,9 @@ final class XcodeIconsExporterTests: XCTestCase {
         XCTAssertEqual(result.count, 6)
         XCTAssertTrue(result[0].destination.url.absoluteString.hasSuffix("Contents.json"))
         XCTAssertTrue(result[1].destination.url.absoluteString.hasSuffix("image1.imageset/Contents.json"))
-        XCTAssertTrue(result[2].destination.url.absoluteString.hasSuffix("image1.imageset/image1L.pdf"))
+        XCTAssertTrue(result[2].destination.url.absoluteString.hasSuffix("image1.imageset/image1.pdf"))
         XCTAssertTrue(result[3].destination.url.absoluteString.hasSuffix("image2.imageset/Contents.json"))
-        XCTAssertTrue(result[4].destination.url.absoluteString.hasSuffix("image2.imageset/image2L.pdf"))
+        XCTAssertTrue(result[4].destination.url.absoluteString.hasSuffix("image2.imageset/image2.pdf"))
         XCTAssertTrue(result[5].destination.url.absoluteString.hasSuffix("Image+extension.swift"))
 
         let content = result[5].data
@@ -255,7 +255,7 @@ final class XcodeIconsExporterTests: XCTestCase {
         XCTAssertEqual(result.count, 4)
         XCTAssertTrue(result[0].destination.url.absoluteString.hasSuffix("Contents.json"))
         XCTAssertTrue(result[1].destination.url.absoluteString.hasSuffix("image1.imageset/Contents.json"))
-        XCTAssertTrue(result[2].destination.url.absoluteString.hasSuffix("image1.imageset/image1L.pdf"))
+        XCTAssertTrue(result[2].destination.url.absoluteString.hasSuffix("image1.imageset/image1.pdf"))
         XCTAssertTrue(result[3].destination.url.absoluteString.hasSuffix("UIImage+extension.swift"))
 
         try write(file: result[3])
@@ -268,7 +268,7 @@ final class XcodeIconsExporterTests: XCTestCase {
         XCTAssertEqual(appendResult.count, 4)
         XCTAssertTrue(appendResult[0].destination.url.absoluteString.hasSuffix("Contents.json"))
         XCTAssertTrue(appendResult[1].destination.url.absoluteString.hasSuffix("image2.imageset/Contents.json"))
-        XCTAssertTrue(appendResult[2].destination.url.absoluteString.hasSuffix("image2.imageset/image2L.pdf"))
+        XCTAssertTrue(appendResult[2].destination.url.absoluteString.hasSuffix("image2.imageset/image2.pdf"))
         let resultContent = try XCTUnwrap(appendResult[3].data)
 
         let generatedCode = String(data: resultContent, encoding: .utf8)

--- a/Tests/XcodeExportTests/XcodeIconsExporterTests.swift
+++ b/Tests/XcodeExportTests/XcodeIconsExporterTests.swift
@@ -8,7 +8,9 @@ final class XcodeIconsExporterTests: XCTestCase {
     // MARK: - Properties
 
     private let image1 = Image(name: "image1", url: URL(string: "1")!, format: "pdf")
+    private let image1Dark = Image(name: "image1", url: URL(string: "1_dark")!, format: "pdf")
     private let image2 = Image(name: "image2", url: URL(string: "2")!, format: "pdf")
+    private let image2Dark = Image(name: "image2", url: URL(string: "2_dark")!, format: "pdf")
 
     private let uiKitImageExtensionURL = FileManager.default
         .temporaryDirectory
@@ -36,6 +38,43 @@ final class XcodeIconsExporterTests: XCTestCase {
         XCTAssertTrue(result[5].destination.url.absoluteString.hasSuffix("UIImage+extension.swift"))
 
         let content = result[5].data
+        XCTAssertNotNil(content)
+
+        let generatedCode = String(data: content!, encoding: .utf8)
+        let referenceCode = """
+        \(header)
+
+        import UIKit
+
+        public extension UIImage {
+            static var image1: UIImage { UIImage(named: #function)! }
+            static var image2: UIImage { UIImage(named: #function)! }
+        }
+
+        """
+        XCTAssertEqual(generatedCode, referenceCode)
+    }
+
+    func testExportPair() throws {
+        let output = XcodeImagesOutput(assetsFolderURL: URL(string: "~/")!, assetsInMainBundle: true, uiKitImageExtensionURL: uiKitImageExtensionURL)
+        let exporter = XcodeIconsExporter(output: output)
+        let result = try exporter.export(
+            icons: [AssetPair(light: ImagePack(image: image1), dark: ImagePack(image: image1Dark)),
+                    AssetPair(light: ImagePack(image: image2), dark: ImagePack(image: image2Dark))],
+            append: false
+        )
+
+        XCTAssertEqual(result.count, 8)
+        XCTAssertTrue(result[0].destination.url.absoluteString.hasSuffix("Contents.json"))
+        XCTAssertTrue(result[1].destination.url.absoluteString.hasSuffix("image1.imageset/Contents.json"))
+        XCTAssertTrue(result[2].destination.url.absoluteString.hasSuffix("image1.imageset/image1L.pdf"))
+        XCTAssertTrue(result[3].destination.url.absoluteString.hasSuffix("image1.imageset/image1D.pdf"))
+        XCTAssertTrue(result[4].destination.url.absoluteString.hasSuffix("image2.imageset/Contents.json"))
+        XCTAssertTrue(result[5].destination.url.absoluteString.hasSuffix("image2.imageset/image2L.pdf"))
+        XCTAssertTrue(result[6].destination.url.absoluteString.hasSuffix("image2.imageset/image2D.pdf"))
+        XCTAssertTrue(result[7].destination.url.absoluteString.hasSuffix("UIImage+extension.swift"))
+
+        let content = result[7].data
         XCTAssertNotNil(content)
 
         let generatedCode = String(data: content!, encoding: .utf8)
@@ -92,6 +131,48 @@ final class XcodeIconsExporterTests: XCTestCase {
         XCTAssertEqual(generatedCode, referenceCode)
     }
 
+    func testExportPairWithObjc() throws {
+        let output = XcodeImagesOutput(
+            assetsFolderURL: URL(string: "~/")!,
+            assetsInMainBundle: true,
+            addObjcAttribute: true,
+            uiKitImageExtensionURL: URL(string: "~/UIImage+extension.swift")!
+        )
+        let exporter = XcodeIconsExporter(output: output)
+        let result = try exporter.export(
+            icons: [AssetPair(light: ImagePack(image: image1), dark: ImagePack(image: image1Dark)),
+                    AssetPair(light: ImagePack(image: image2), dark: ImagePack(image: image2Dark))],
+            append: false
+        )
+
+        XCTAssertEqual(result.count, 8)
+        XCTAssertTrue(result[0].destination.url.absoluteString.hasSuffix("Contents.json"))
+        XCTAssertTrue(result[1].destination.url.absoluteString.hasSuffix("image1.imageset/Contents.json"))
+        XCTAssertTrue(result[2].destination.url.absoluteString.hasSuffix("image1.imageset/image1L.pdf"))
+        XCTAssertTrue(result[3].destination.url.absoluteString.hasSuffix("image1.imageset/image1D.pdf"))
+        XCTAssertTrue(result[4].destination.url.absoluteString.hasSuffix("image2.imageset/Contents.json"))
+        XCTAssertTrue(result[5].destination.url.absoluteString.hasSuffix("image2.imageset/image2L.pdf"))
+        XCTAssertTrue(result[6].destination.url.absoluteString.hasSuffix("image2.imageset/image2D.pdf"))
+        XCTAssertTrue(result[7].destination.url.absoluteString.hasSuffix("UIImage+extension.swift"))
+
+        let content = result[7].data
+        XCTAssertNotNil(content)
+
+        let generatedCode = String(data: content!, encoding: .utf8)
+        let referenceCode = """
+        \(header)
+
+        import UIKit
+
+        public extension UIImage {
+            @objc static var image1: UIImage { UIImage(named: #function)! }
+            @objc static var image2: UIImage { UIImage(named: #function)! }
+        }
+
+        """
+        XCTAssertEqual(generatedCode, referenceCode)
+    }
+
     func testExportInSeparateBundle() throws {
         let output = XcodeImagesOutput(assetsFolderURL: URL(string: "~/")!, assetsInMainBundle: false, assetsInSwiftPackage: false, uiKitImageExtensionURL: uiKitImageExtensionURL)
         let exporter = XcodeIconsExporter(output: output)
@@ -109,6 +190,47 @@ final class XcodeIconsExporterTests: XCTestCase {
         XCTAssertTrue(result[5].destination.url.absoluteString.hasSuffix("UIImage+extension.swift"))
 
         let content = result[5].data
+        XCTAssertNotNil(content)
+
+        let generatedCode = String(data: content!, encoding: .utf8)
+        let referenceCode = """
+        \(header)
+
+        import UIKit
+
+        private class BundleProvider {
+            static let bundle = Bundle(for: BundleProvider.self)
+        }
+
+        public extension UIImage {
+            static var image1: UIImage { UIImage(named: #function, in: BundleProvider.bundle, compatibleWith: nil)! }
+            static var image2: UIImage { UIImage(named: #function, in: BundleProvider.bundle, compatibleWith: nil)! }
+        }
+
+        """
+        XCTAssertEqual(generatedCode, referenceCode)
+    }
+
+    func testExportPairInSeparateBundle() throws {
+        let output = XcodeImagesOutput(assetsFolderURL: URL(string: "~/")!, assetsInMainBundle: false, assetsInSwiftPackage: false, uiKitImageExtensionURL: uiKitImageExtensionURL)
+        let exporter = XcodeIconsExporter(output: output)
+        let result = try exporter.export(
+            icons: [AssetPair(light: ImagePack(image: image1), dark: ImagePack(image: image1Dark)),
+                    AssetPair(light: ImagePack(image: image2), dark: ImagePack(image: image2Dark))],
+            append: false
+        )
+
+        XCTAssertEqual(result.count, 8)
+        XCTAssertTrue(result[0].destination.url.absoluteString.hasSuffix("Contents.json"))
+        XCTAssertTrue(result[1].destination.url.absoluteString.hasSuffix("image1.imageset/Contents.json"))
+        XCTAssertTrue(result[2].destination.url.absoluteString.hasSuffix("image1.imageset/image1L.pdf"))
+        XCTAssertTrue(result[3].destination.url.absoluteString.hasSuffix("image1.imageset/image1D.pdf"))
+        XCTAssertTrue(result[4].destination.url.absoluteString.hasSuffix("image2.imageset/Contents.json"))
+        XCTAssertTrue(result[5].destination.url.absoluteString.hasSuffix("image2.imageset/image2L.pdf"))
+        XCTAssertTrue(result[6].destination.url.absoluteString.hasSuffix("image2.imageset/image2D.pdf"))
+        XCTAssertTrue(result[7].destination.url.absoluteString.hasSuffix("UIImage+extension.swift"))
+
+        let content = result[7].data
         XCTAssertNotNil(content)
 
         let generatedCode = String(data: content!, encoding: .utf8)
@@ -168,6 +290,47 @@ final class XcodeIconsExporterTests: XCTestCase {
         XCTAssertEqual(generatedCode, referenceCode)
     }
 
+    func testExportPairInSwiftPackage() throws {
+        let output = XcodeImagesOutput(assetsFolderURL: URL(string: "~/")!, assetsInMainBundle: false, assetsInSwiftPackage: true, uiKitImageExtensionURL: uiKitImageExtensionURL)
+        let exporter = XcodeIconsExporter(output: output)
+        let result = try exporter.export(
+            icons: [AssetPair(light: ImagePack(image: image1), dark: ImagePack(image: image1Dark)),
+                    AssetPair(light: ImagePack(image: image2), dark: ImagePack(image: image2Dark))],
+            append: false
+        )
+
+        XCTAssertEqual(result.count, 8)
+        XCTAssertTrue(result[0].destination.url.absoluteString.hasSuffix("Contents.json"))
+        XCTAssertTrue(result[1].destination.url.absoluteString.hasSuffix("image1.imageset/Contents.json"))
+        XCTAssertTrue(result[2].destination.url.absoluteString.hasSuffix("image1.imageset/image1L.pdf"))
+        XCTAssertTrue(result[3].destination.url.absoluteString.hasSuffix("image1.imageset/image1D.pdf"))
+        XCTAssertTrue(result[4].destination.url.absoluteString.hasSuffix("image2.imageset/Contents.json"))
+        XCTAssertTrue(result[5].destination.url.absoluteString.hasSuffix("image2.imageset/image2L.pdf"))
+        XCTAssertTrue(result[6].destination.url.absoluteString.hasSuffix("image2.imageset/image2D.pdf"))
+        XCTAssertTrue(result[7].destination.url.absoluteString.hasSuffix("UIImage+extension.swift"))
+
+        let content = result[7].data
+        XCTAssertNotNil(content)
+
+        let generatedCode = String(data: content!, encoding: .utf8)
+        let referenceCode = """
+        \(header)
+
+        import UIKit
+
+        private class BundleProvider {
+            static let bundle = Bundle.module
+        }
+
+        public extension UIImage {
+            static var image1: UIImage { UIImage(named: #function, in: BundleProvider.bundle, compatibleWith: nil)! }
+            static var image2: UIImage { UIImage(named: #function, in: BundleProvider.bundle, compatibleWith: nil)! }
+        }
+
+        """
+        XCTAssertEqual(generatedCode, referenceCode)
+    }
+
     func testExportSwiftUI() throws {
         let output = XcodeImagesOutput(assetsFolderURL: URL(string: "~/")!, assetsInMainBundle: true, swiftUIImageExtensionURL: swiftUIImageExtensionURL)
         let exporter = XcodeIconsExporter(output: output)
@@ -185,6 +348,43 @@ final class XcodeIconsExporterTests: XCTestCase {
         XCTAssertTrue(result[5].destination.url.absoluteString.hasSuffix("Image+extension.swift"))
 
         let content = result[5].data
+        XCTAssertNotNil(content)
+
+        let generatedCode = String(data: content!, encoding: .utf8)
+        let referenceCode = """
+        \(header)
+
+        import SwiftUI
+
+        public extension Image {
+            static var image1: Image { Image(#function) }
+            static var image2: Image { Image(#function) }
+        }
+
+        """
+        XCTAssertEqual(generatedCode, referenceCode)
+    }
+
+    func testExportPairSwiftUI() throws {
+        let output = XcodeImagesOutput(assetsFolderURL: URL(string: "~/")!, assetsInMainBundle: true, swiftUIImageExtensionURL: swiftUIImageExtensionURL)
+        let exporter = XcodeIconsExporter(output: output)
+        let result = try exporter.export(
+            icons: [AssetPair(light: ImagePack(image: image1), dark: ImagePack(image: image1Dark)),
+                    AssetPair(light: ImagePack(image: image2), dark: ImagePack(image: image2Dark))],
+            append: false
+        )
+
+        XCTAssertEqual(result.count, 8)
+        XCTAssertTrue(result[0].destination.url.absoluteString.hasSuffix("Contents.json"))
+        XCTAssertTrue(result[1].destination.url.absoluteString.hasSuffix("image1.imageset/Contents.json"))
+        XCTAssertTrue(result[2].destination.url.absoluteString.hasSuffix("image1.imageset/image1L.pdf"))
+        XCTAssertTrue(result[3].destination.url.absoluteString.hasSuffix("image1.imageset/image1D.pdf"))
+        XCTAssertTrue(result[4].destination.url.absoluteString.hasSuffix("image2.imageset/Contents.json"))
+        XCTAssertTrue(result[5].destination.url.absoluteString.hasSuffix("image2.imageset/image2L.pdf"))
+        XCTAssertTrue(result[6].destination.url.absoluteString.hasSuffix("image2.imageset/image2D.pdf"))
+        XCTAssertTrue(result[7].destination.url.absoluteString.hasSuffix("Image+extension.swift"))
+
+        let content = result[7].data
         XCTAssertNotNil(content)
 
         let generatedCode = String(data: content!, encoding: .utf8)
@@ -240,6 +440,47 @@ final class XcodeIconsExporterTests: XCTestCase {
         XCTAssertEqual(generatedCode, referenceCode)
     }
 
+    func testExportPairSwiftUIInSeparateBundle() throws {
+        let output = XcodeImagesOutput(assetsFolderURL: URL(string: "~/")!, assetsInMainBundle: false, swiftUIImageExtensionURL: swiftUIImageExtensionURL)
+        let exporter = XcodeIconsExporter(output: output)
+        let result = try exporter.export(
+            icons: [AssetPair(light: ImagePack(image: image1), dark: ImagePack(image: image1Dark)),
+                    AssetPair(light: ImagePack(image: image2), dark: ImagePack(image: image2Dark))],
+            append: false
+        )
+
+        XCTAssertEqual(result.count, 8)
+        XCTAssertTrue(result[0].destination.url.absoluteString.hasSuffix("Contents.json"))
+        XCTAssertTrue(result[1].destination.url.absoluteString.hasSuffix("image1.imageset/Contents.json"))
+        XCTAssertTrue(result[2].destination.url.absoluteString.hasSuffix("image1.imageset/image1L.pdf"))
+        XCTAssertTrue(result[3].destination.url.absoluteString.hasSuffix("image1.imageset/image1D.pdf"))
+        XCTAssertTrue(result[4].destination.url.absoluteString.hasSuffix("image2.imageset/Contents.json"))
+        XCTAssertTrue(result[5].destination.url.absoluteString.hasSuffix("image2.imageset/image2L.pdf"))
+        XCTAssertTrue(result[6].destination.url.absoluteString.hasSuffix("image2.imageset/image2D.pdf"))
+        XCTAssertTrue(result[7].destination.url.absoluteString.hasSuffix("Image+extension.swift"))
+
+        let content = result[7].data
+        XCTAssertNotNil(content)
+
+        let generatedCode = String(data: content!, encoding: .utf8)
+        let referenceCode = """
+        \(header)
+
+        import SwiftUI
+
+        private class BundleProvider {
+            static let bundle = Bundle(for: BundleProvider.self)
+        }
+
+        public extension Image {
+            static var image1: Image { Image(#function, bundle: BundleProvider.bundle) }
+            static var image2: Image { Image(#function, bundle: BundleProvider.bundle) }
+        }
+
+        """
+        XCTAssertEqual(generatedCode, referenceCode)
+    }
+
     func testAppendAfterExport() throws {
         let output = XcodeImagesOutput(
             assetsFolderURL: URL(string: "~/")!,
@@ -269,6 +510,7 @@ final class XcodeIconsExporterTests: XCTestCase {
         XCTAssertTrue(appendResult[0].destination.url.absoluteString.hasSuffix("Contents.json"))
         XCTAssertTrue(appendResult[1].destination.url.absoluteString.hasSuffix("image2.imageset/Contents.json"))
         XCTAssertTrue(appendResult[2].destination.url.absoluteString.hasSuffix("image2.imageset/image2.pdf"))
+        XCTAssertTrue(appendResult[3].destination.url.absoluteString.hasSuffix("UIImage+extension.swift"))
         let resultContent = try XCTUnwrap(appendResult[3].data)
 
         let generatedCode = String(data: resultContent, encoding: .utf8)
@@ -285,6 +527,56 @@ final class XcodeIconsExporterTests: XCTestCase {
         """
         XCTAssertEqual(generatedCode, referenceCode)
     }
+
+    func testAppendPairAfterExport() throws {
+        let output = XcodeImagesOutput(
+            assetsFolderURL: URL(string: "~/")!,
+            assetsInMainBundle: true,
+            uiKitImageExtensionURL: uiKitImageExtensionURL
+        )
+        let exporter = XcodeIconsExporter(output: output)
+        let result = try exporter.export(
+            icons: [AssetPair(light: ImagePack(image: image1), dark: ImagePack(image: image1Dark))],
+            append: false
+        )
+
+        XCTAssertEqual(result.count, 5)
+        XCTAssertTrue(result[0].destination.url.absoluteString.hasSuffix("Contents.json"))
+        XCTAssertTrue(result[1].destination.url.absoluteString.hasSuffix("image1.imageset/Contents.json"))
+        XCTAssertTrue(result[2].destination.url.absoluteString.hasSuffix("image1.imageset/image1L.pdf"))
+        XCTAssertTrue(result[3].destination.url.absoluteString.hasSuffix("image1.imageset/image1D.pdf"))
+        XCTAssertTrue(result[4].destination.url.absoluteString.hasSuffix("UIImage+extension.swift"))
+
+        try write(file: result[4])
+
+        let appendResult = try exporter.export(
+            icons: [AssetPair(light: ImagePack(image: image2), dark: ImagePack(image: image2Dark))],
+            append: true
+        )
+
+        XCTAssertEqual(appendResult.count, 5)
+        XCTAssertTrue(appendResult[0].destination.url.absoluteString.hasSuffix("Contents.json"))
+        XCTAssertTrue(appendResult[1].destination.url.absoluteString.hasSuffix("image2.imageset/Contents.json"))
+        XCTAssertTrue(appendResult[2].destination.url.absoluteString.hasSuffix("image2.imageset/image2L.pdf"))
+        XCTAssertTrue(appendResult[3].destination.url.absoluteString.hasSuffix("image2.imageset/image2D.pdf"))
+        XCTAssertTrue(appendResult[4].destination.url.absoluteString.hasSuffix("UIImage+extension.swift"))
+        let resultContent = try XCTUnwrap(appendResult[4].data)
+
+        let generatedCode = String(data: resultContent, encoding: .utf8)
+        let referenceCode = """
+        \(header)
+
+        import UIKit
+
+        public extension UIImage {
+            static var image1: UIImage { UIImage(named: #function)! }
+            static var image2: UIImage { UIImage(named: #function)! }
+        }
+
+        """
+        XCTAssertEqual(generatedCode, referenceCode)
+    }
+
 }
 
 private extension XcodeIconsExporterTests {


### PR DESCRIPTION
Adds two configuration options to the common.icons and common.images portion of the yaml file. 
