### PR TITLE
Name is optional in xcodeproj, so compare the path instead

### DIFF
--- a/Sources/FigmaExport/Output/XcodeProjectWriter.swift
+++ b/Sources/FigmaExport/Output/XcodeProjectWriter.swift
@@ -58,8 +58,7 @@ final class XcodeProjectWriter {
                 groups = Array(groups.dropFirst())
             }
         }
-        
-        guard currentGroup?.file(named: url.lastPathComponent) == nil else { return }
+        guard currentGroup?.children.first(where: {$0.path == url.lastPathComponent}) == nil else { return }
         
         let newFile = try currentGroup?.addFile(
             at: Path(url.path),


### PR DESCRIPTION
the `group.file` command only looks for file references by name, but there's no guarantee that a reference actually has a name. (changing target membership seems to clear the name)