### PR TITLE
Fix SwiftUI preview crashes when accessing assets from a nested Swift Package.

### DIFF
--- a/CONFIG.md
+++ b/CONFIG.md
@@ -81,6 +81,8 @@ ios:
   xcassetsInMainBundle: true
   # [optional] Is Assets.xcassets located in a swift package? Default value is false.
   xcassetsInSwiftPackage: false
+  # [optional] When `xcassetsInSwiftPackage: true` use this property to specify a resource bundle name for Swift packages containing Assets.xcassets (e.g. ["PackageName_TargetName"]). This is necessary to avoid SwiftUI Preview crashes.
+  resourceBundleNames: []
   # [optional] Add @objc attribute to generated properties so that they are accessible in Objective-C. Defaults to false
   addObjcAttribute: false
   # [optional] Path to the Stencil templates used to generate code

--- a/Sources/FigmaExport/Input/Params.swift
+++ b/Sources/FigmaExport/Input/Params.swift
@@ -105,6 +105,7 @@ struct Params: Decodable {
         let xcassetsPath: URL
         let xcassetsInMainBundle: Bool
         let xcassetsInSwiftPackage: Bool?
+        let resourceBundleNames: [String]
         let addObjcAttribute: Bool?
         let templatesPath: URL?
 

--- a/Sources/FigmaExport/Input/Params.swift
+++ b/Sources/FigmaExport/Input/Params.swift
@@ -105,7 +105,7 @@ struct Params: Decodable {
         let xcassetsPath: URL
         let xcassetsInMainBundle: Bool
         let xcassetsInSwiftPackage: Bool?
-        let resourceBundleNames: [String]
+        let resourceBundleNames: [String]?
         let addObjcAttribute: Bool?
         let templatesPath: URL?
 

--- a/Sources/FigmaExport/Resources/iOSConfig.swift
+++ b/Sources/FigmaExport/Resources/iOSConfig.swift
@@ -63,6 +63,8 @@ ios:
   xcassetsInMainBundle: true
   # [optional] Is Assets.xcassets located in a swift package? Default value is false.
   xcassetsInSwiftPackage: false
+  # [optional] Resource bundle name for Swift packages containing Assets.xcassets (e.g. ["PackageName_TargetName"])
+  resourceBundleNames: []
   # [optional] Add @objc attribute to generated properties so that they are accessible in Objective-C. Defaults to false
   addObjcAttribute: false
                          

--- a/Sources/FigmaExport/Resources/iOSConfig.swift
+++ b/Sources/FigmaExport/Resources/iOSConfig.swift
@@ -63,7 +63,7 @@ ios:
   xcassetsInMainBundle: true
   # [optional] Is Assets.xcassets located in a swift package? Default value is false.
   xcassetsInSwiftPackage: false
-  # [optional] Resource bundle name for Swift packages containing Assets.xcassets (e.g. ["PackageName_TargetName"])
+  # [optional] When `xcassetsInSwiftPackage: true` use this property to specify a resource bundle name for Swift packages containing Assets.xcassets (e.g. ["PackageName_TargetName"]). This is necessary to avoid SwiftUI Preview crashes.
   resourceBundleNames: []
   # [optional] Add @objc attribute to generated properties so that they are accessible in Objective-C. Defaults to false
   addObjcAttribute: false

--- a/Sources/FigmaExport/Subcommands/ExportColors.swift
+++ b/Sources/FigmaExport/Subcommands/ExportColors.swift
@@ -98,6 +98,7 @@ extension FigmaExportCommand {
                 assetsColorsURL: colorsURL,
                 assetsInMainBundle: iosParams.xcassetsInMainBundle,
                 assetsInSwiftPackage: iosParams.xcassetsInSwiftPackage,
+                resourceBundleNames: iosParams.resourceBundleNames,
                 addObjcAttribute: iosParams.addObjcAttribute,
                 colorSwiftURL: colorParams.colorSwift,
                 swiftuiColorSwiftURL: colorParams.swiftuiColorSwift,

--- a/Sources/FigmaExport/Subcommands/ExportIcons.swift
+++ b/Sources/FigmaExport/Subcommands/ExportIcons.swift
@@ -68,6 +68,7 @@ extension FigmaExportCommand {
                 assetsFolderURL: assetsURL,
                 assetsInMainBundle: ios.xcassetsInMainBundle,
                 assetsInSwiftPackage: ios.xcassetsInSwiftPackage,
+                resourceBundleNames: ios.resourceBundleNames,
                 addObjcAttribute: ios.addObjcAttribute,
                 preservesVectorRepresentation: iconsParams.preservesVectorRepresentation,
                 uiKitImageExtensionURL: iconsParams.imageSwift,

--- a/Sources/FigmaExport/Subcommands/ExportImages.swift
+++ b/Sources/FigmaExport/Subcommands/ExportImages.swift
@@ -67,6 +67,7 @@ extension FigmaExportCommand {
                 assetsFolderURL: assetsURL,
                 assetsInMainBundle: ios.xcassetsInMainBundle,
                 assetsInSwiftPackage: ios.xcassetsInSwiftPackage,
+                resourceBundleNames: ios.resourceBundleNames,
                 addObjcAttribute: ios.addObjcAttribute,
                 uiKitImageExtensionURL: imagesParams.imageSwift,
                 swiftUIImageExtensionURL: imagesParams.swiftUIImageSwift)

--- a/Sources/XcodeExport/Model/XcodeColorsOutput.swift
+++ b/Sources/XcodeExport/Model/XcodeColorsOutput.swift
@@ -6,7 +6,7 @@ public struct XcodeColorsOutput {
     public let assetsColorsURL: URL?
     public let assetsInMainBundle: Bool
     public let assetsInSwiftPackage: Bool
-    public let resourceBundleNames: [String]
+    public let resourceBundleNames: [String]?
     public let addObjcAttribute: Bool
     public let colorSwiftURL: URL?
     public let swiftuiColorSwiftURL: URL?
@@ -17,7 +17,7 @@ public struct XcodeColorsOutput {
         assetsColorsURL: URL?,
         assetsInMainBundle: Bool,
         assetsInSwiftPackage: Bool? = false,
-        resourceBundleNames: [String] = [],
+        resourceBundleNames: [String]? = nil,
         addObjcAttribute: Bool? = false,
         colorSwiftURL: URL? = nil,
         swiftuiColorSwiftURL: URL? = nil,

--- a/Sources/XcodeExport/Model/XcodeColorsOutput.swift
+++ b/Sources/XcodeExport/Model/XcodeColorsOutput.swift
@@ -6,6 +6,7 @@ public struct XcodeColorsOutput {
     public let assetsColorsURL: URL?
     public let assetsInMainBundle: Bool
     public let assetsInSwiftPackage: Bool
+    public let resourceBundleNames: [String]
     public let addObjcAttribute: Bool
     public let colorSwiftURL: URL?
     public let swiftuiColorSwiftURL: URL?
@@ -16,6 +17,7 @@ public struct XcodeColorsOutput {
         assetsColorsURL: URL?,
         assetsInMainBundle: Bool,
         assetsInSwiftPackage: Bool? = false,
+        resourceBundleNames: [String] = [],
         addObjcAttribute: Bool? = false,
         colorSwiftURL: URL? = nil,
         swiftuiColorSwiftURL: URL? = nil,
@@ -25,6 +27,7 @@ public struct XcodeColorsOutput {
         self.assetsColorsURL = assetsColorsURL
         self.assetsInMainBundle = assetsInMainBundle
         self.assetsInSwiftPackage = assetsInSwiftPackage ?? false
+        self.resourceBundleNames = resourceBundleNames
         self.addObjcAttribute = addObjcAttribute ?? false
         self.colorSwiftURL = colorSwiftURL
         self.swiftuiColorSwiftURL = swiftuiColorSwiftURL

--- a/Sources/XcodeExport/Model/XcodeImagesOutput.swift
+++ b/Sources/XcodeExport/Model/XcodeImagesOutput.swift
@@ -6,7 +6,7 @@ public struct XcodeImagesOutput {
     let assetsFolderURL: URL
     let assetsInMainBundle: Bool
     let assetsInSwiftPackage: Bool
-    let resourceBundleNames: [String]
+    let resourceBundleNames: [String]?
     let addObjcAttribute: Bool
     let preservesVectorRepresentation: [String]?
     let renderMode: XcodeRenderMode?
@@ -28,7 +28,7 @@ public struct XcodeImagesOutput {
         assetsFolderURL: URL,
         assetsInMainBundle: Bool,
         assetsInSwiftPackage: Bool? = false,
-        resourceBundleNames: [String] = [],
+        resourceBundleNames: [String]? = nil,
         addObjcAttribute: Bool? = false,
         preservesVectorRepresentation: [String]? = nil,
         uiKitImageExtensionURL: URL? = nil,

--- a/Sources/XcodeExport/Model/XcodeImagesOutput.swift
+++ b/Sources/XcodeExport/Model/XcodeImagesOutput.swift
@@ -6,6 +6,7 @@ public struct XcodeImagesOutput {
     let assetsFolderURL: URL
     let assetsInMainBundle: Bool
     let assetsInSwiftPackage: Bool
+    let resourceBundleNames: [String]
     let addObjcAttribute: Bool
     let preservesVectorRepresentation: [String]?
     let renderMode: XcodeRenderMode?
@@ -27,6 +28,7 @@ public struct XcodeImagesOutput {
         assetsFolderURL: URL,
         assetsInMainBundle: Bool,
         assetsInSwiftPackage: Bool? = false,
+        resourceBundleNames: [String] = [],
         addObjcAttribute: Bool? = false,
         preservesVectorRepresentation: [String]? = nil,
         uiKitImageExtensionURL: URL? = nil,
@@ -40,6 +42,7 @@ public struct XcodeImagesOutput {
         self.assetsFolderURL = assetsFolderURL
         self.assetsInMainBundle = assetsInMainBundle
         self.assetsInSwiftPackage = assetsInSwiftPackage ?? false
+        self.resourceBundleNames = resourceBundleNames
         self.addObjcAttribute = addObjcAttribute ?? false
         self.preservesVectorRepresentation = preservesVectorRepresentation
         self.uiKitImageExtensionURL = uiKitImageExtensionURL

--- a/Sources/XcodeExport/Resources/Bundle+extension.swift.stencil.include
+++ b/Sources/XcodeExport/Resources/Bundle+extension.swift.stencil.include
@@ -1,0 +1,34 @@
+{% if resourceBundleNames %}
+private extension Foundation.Bundle {
+    private class BundleFinder {}
+
+    /// Returns the resource bundle associated with the current Swift module.
+    static var _module: Bundle = {
+        let bundleNames = {{ resourceBundleNames }}
+
+        let candidates = [
+            // Bundle should be present here when the package is linked into an App.
+            Bundle.main.resourceURL,
+            // Bundle should be present here when the package is linked into a framework.
+            Bundle(for: BundleFinder.self).resourceURL,
+            // Bundle should be present here when the package is used in UI Tests.
+            Bundle(for: BundleFinder.self).resourceURL?.deletingLastPathComponent(),
+            // For command-line tools.
+            Bundle.main.bundleURL,
+            // Bundle should be present here when running previews from a different package (this is the path to "…/Debug-iphonesimulator/").
+            Bundle(for: BundleFinder.self).resourceURL?.deletingLastPathComponent().deletingLastPathComponent().deletingLastPathComponent(),
+            Bundle(for: BundleFinder.self).resourceURL?.deletingLastPathComponent().deletingLastPathComponent()
+        ]
+
+        for candidate in candidates {
+            for bundleName in bundleNames {
+                let bundlePathiOS = candidate?.appendingPathComponent(bundleName + ".bundle")
+                if let bundle = bundlePathiOS.flatMap(Bundle.init(url:)) {
+                    return bundle
+                }
+            }
+        }
+        fatalError("unable to find bundle named \(bundleNames)")
+    }()
+}
+{% endif %}

--- a/Sources/XcodeExport/Resources/Bundle+extension.swift.stencil.include
+++ b/Sources/XcodeExport/Resources/Bundle+extension.swift.stencil.include
@@ -6,19 +6,26 @@ private extension Foundation.Bundle {
     static var _module: Bundle = {
         let bundleNames = {{ resourceBundleNames }}
 
-        let candidates = [
-            // Bundle should be present here when the package is linked into an App.
-            Bundle.main.resourceURL,
-            // Bundle should be present here when the package is linked into a framework.
-            Bundle(for: BundleFinder.self).resourceURL,
-            // Bundle should be present here when the package is used in UI Tests.
-            Bundle(for: BundleFinder.self).resourceURL?.deletingLastPathComponent(),
-            // For command-line tools.
-            Bundle.main.bundleURL,
-            // Bundle should be present here when running previews from a different package (this is the path to "…/Debug-iphonesimulator/").
-            Bundle(for: BundleFinder.self).resourceURL?.deletingLastPathComponent().deletingLastPathComponent().deletingLastPathComponent(),
-            Bundle(for: BundleFinder.self).resourceURL?.deletingLastPathComponent().deletingLastPathComponent()
-        ]
+        let candidates: [URL?] = {
+            var candidates = [
+                // Bundle should be present here when the package is linked into an App.
+                Bundle.main.resourceURL,
+                // Bundle should be present here when the package is linked into a framework.
+                Bundle(for: BundleFinder.self).resourceURL,
+                // For command-line tools.
+                Bundle.main.bundleURL,
+            ]
+#if DEBUG
+            candidates.append(contentsOf: [
+                // Bundle should be present here when the package is used in UI Tests.
+                Bundle(for: BundleFinder.self).resourceURL?.deletingLastPathComponent(),
+                // Bundle should be present here when running previews from a different package (this is the path to "…/Debug-iphonesimulator/").
+                Bundle(for: BundleFinder.self).resourceURL?.deletingLastPathComponent().deletingLastPathComponent().deletingLastPathComponent(),
+                Bundle(for: BundleFinder.self).resourceURL?.deletingLastPathComponent().deletingLastPathComponent(),
+            ])
+#endif
+            return candidates
+        }()
 
         for candidate in candidates {
             for bundleName in bundleNames {

--- a/Sources/XcodeExport/Resources/Color+extension.swift.stencil
+++ b/Sources/XcodeExport/Resources/Color+extension.swift.stencil
@@ -1,15 +1,52 @@
 {% include "header.stencil" %}
 import SwiftUI
-{% if assetsInSwiftPackage %}
+{% if assetsInSwiftPackage and resourceBundleNames %}
+private class BundleProvider {
+    static let bundle = Bundle._module
+}
+{% elif assetsInSwiftPackage and not resourceBundleNames %}
 private class BundleProvider {
     static let bundle = Bundle.module
 }
-{% elif not assetsInMainBundle %}
+{% elif not assetsInSwiftPackage and not resourceBundleNames %}
 private class BundleProvider {
     static let bundle = Bundle(for: BundleProvider.self)
 }
-
 {% endif %}
 public extension Color {{ "{" }}{% for color in colors %}
     static var {{ color.name }}: Color { Color({% if useNamespace %}"{{ color.originalName }}"{% else %}#function{% endif %}{% if not assetsInMainBundle %}, bundle: BundleProvider.bundle{% endif %}) }{% endfor %}
 }
+{% if resourceBundleNames %}
+private extension Foundation.Bundle {
+    private class BundleFinder {}
+
+    // Returns the resource bundle associated with the current Swift module.
+    static var _module: Bundle = {
+        let bundleNames = {{ resourceBundleNames }}
+
+        let candidates = [
+            // Bundle should be present here when the package is linked into an App.
+            Bundle.main.resourceURL,
+            // Bundle should be present here when the package is linked into a framework.
+            Bundle(for: BundleFinder.self).resourceURL,
+            // Bundle should be present here when the package is used in UI Tests.
+            Bundle(for: BundleFinder.self).resourceURL?.deletingLastPathComponent(),
+            // For command-line tools.
+            Bundle.main.bundleURL,
+            // Bundle should be present here when running previews from a different package (this is the path to "…/Debug-iphonesimulator/").
+            Bundle(for: BundleFinder.self).resourceURL?.deletingLastPathComponent().deletingLastPathComponent().deletingLastPathComponent(),
+            Bundle(for: BundleFinder.self).resourceURL?.deletingLastPathComponent().deletingLastPathComponent()
+        ]
+
+        for candidate in candidates {
+            for bundleName in bundleNames {
+                let bundlePathiOS = candidate?.appendingPathComponent(bundleName + ".bundle")
+                if let bundle = bundlePathiOS.flatMap(Bundle.init(url:)) {
+                    return bundle
+                }
+            }
+        }
+        fatalError("unable to find bundle named \(bundleNames)")
+    }()
+}
+{% endif %}

--- a/Sources/XcodeExport/Resources/Color+extension.swift.stencil
+++ b/Sources/XcodeExport/Resources/Color+extension.swift.stencil
@@ -16,37 +16,4 @@ private class BundleProvider {
 public extension Color {{ "{" }}{% for color in colors %}
     static var {{ color.name }}: Color { Color({% if useNamespace %}"{{ color.originalName }}"{% else %}#function{% endif %}{% if not assetsInMainBundle %}, bundle: BundleProvider.bundle{% endif %}) }{% endfor %}
 }
-{% if resourceBundleNames %}
-private extension Foundation.Bundle {
-    private class BundleFinder {}
-
-    // Returns the resource bundle associated with the current Swift module.
-    static var _module: Bundle = {
-        let bundleNames = {{ resourceBundleNames }}
-
-        let candidates = [
-            // Bundle should be present here when the package is linked into an App.
-            Bundle.main.resourceURL,
-            // Bundle should be present here when the package is linked into a framework.
-            Bundle(for: BundleFinder.self).resourceURL,
-            // Bundle should be present here when the package is used in UI Tests.
-            Bundle(for: BundleFinder.self).resourceURL?.deletingLastPathComponent(),
-            // For command-line tools.
-            Bundle.main.bundleURL,
-            // Bundle should be present here when running previews from a different package (this is the path to "…/Debug-iphonesimulator/").
-            Bundle(for: BundleFinder.self).resourceURL?.deletingLastPathComponent().deletingLastPathComponent().deletingLastPathComponent(),
-            Bundle(for: BundleFinder.self).resourceURL?.deletingLastPathComponent().deletingLastPathComponent()
-        ]
-
-        for candidate in candidates {
-            for bundleName in bundleNames {
-                let bundlePathiOS = candidate?.appendingPathComponent(bundleName + ".bundle")
-                if let bundle = bundlePathiOS.flatMap(Bundle.init(url:)) {
-                    return bundle
-                }
-            }
-        }
-        fatalError("unable to find bundle named \(bundleNames)")
-    }()
-}
-{% endif %}
+{% include "Bundle+extension.swift.stencil.include" %}

--- a/Sources/XcodeExport/Resources/Image+extension.swift.stencil
+++ b/Sources/XcodeExport/Resources/Image+extension.swift.stencil
@@ -1,13 +1,51 @@
 {% include "header.stencil" %}
 import SwiftUI
-{% if assetsInSwiftPackage %}
+{% if assetsInSwiftPackage and resourceBundleNames %}
+private class BundleProvider {
+    static let bundle = Bundle._module
+}
+{% elif assetsInSwiftPackage and not resourceBundleNames %}
 private class BundleProvider {
     static let bundle = Bundle.module
 }
-{% elif not assetsInMainBundle %}
+{% elif not assetsInSwiftPackage and not resourceBundleNames %}
 private class BundleProvider {
     static let bundle = Bundle(for: BundleProvider.self)
 }
 {% endif %}
 public extension Image {{ "{" }}{% include "Image+extension.swift.stencil.include" %}
 }
+{% if resourceBundleNames %}
+private extension Foundation.Bundle {
+    private class BundleFinder {}
+
+    // Returns the resource bundle associated with the current Swift module.
+    static var _module: Bundle = {
+        let bundleNames = {{ resourceBundleNames }}
+
+        let candidates = [
+            // Bundle should be present here when the package is linked into an App.
+            Bundle.main.resourceURL,
+            // Bundle should be present here when the package is linked into a framework.
+            Bundle(for: BundleFinder.self).resourceURL,
+            // Bundle should be present here when the package is used in UI Tests.
+            Bundle(for: BundleFinder.self).resourceURL?.deletingLastPathComponent(),
+            // For command-line tools.
+            Bundle.main.bundleURL,
+            // Bundle should be present here when running previews from a different package (this is the path to "…/Debug-iphonesimulator/").
+            Bundle(for: BundleFinder.self).resourceURL?.deletingLastPathComponent().deletingLastPathComponent().deletingLastPathComponent(),
+            Bundle(for: BundleFinder.self).resourceURL?.deletingLastPathComponent().deletingLastPathComponent()
+        ]
+
+        for candidate in candidates {
+            for bundleName in bundleNames {
+                let bundlePathiOS = candidate?.appendingPathComponent(bundleName + ".bundle")
+                if let bundle = bundlePathiOS.flatMap(Bundle.init(url:)) {
+                    return bundle
+                }
+            }
+        }
+        fatalError("unable to find bundle named \(bundleNames)")
+    }()
+}
+{% endif %}

--- a/Sources/XcodeExport/Resources/Image+extension.swift.stencil
+++ b/Sources/XcodeExport/Resources/Image+extension.swift.stencil
@@ -15,37 +15,4 @@ private class BundleProvider {
 {% endif %}
 public extension Image {{ "{" }}{% include "Image+extension.swift.stencil.include" %}
 }
-{% if resourceBundleNames %}
-private extension Foundation.Bundle {
-    private class BundleFinder {}
-
-    // Returns the resource bundle associated with the current Swift module.
-    static var _module: Bundle = {
-        let bundleNames = {{ resourceBundleNames }}
-
-        let candidates = [
-            // Bundle should be present here when the package is linked into an App.
-            Bundle.main.resourceURL,
-            // Bundle should be present here when the package is linked into a framework.
-            Bundle(for: BundleFinder.self).resourceURL,
-            // Bundle should be present here when the package is used in UI Tests.
-            Bundle(for: BundleFinder.self).resourceURL?.deletingLastPathComponent(),
-            // For command-line tools.
-            Bundle.main.bundleURL,
-            // Bundle should be present here when running previews from a different package (this is the path to "…/Debug-iphonesimulator/").
-            Bundle(for: BundleFinder.self).resourceURL?.deletingLastPathComponent().deletingLastPathComponent().deletingLastPathComponent(),
-            Bundle(for: BundleFinder.self).resourceURL?.deletingLastPathComponent().deletingLastPathComponent()
-        ]
-
-        for candidate in candidates {
-            for bundleName in bundleNames {
-                let bundlePathiOS = candidate?.appendingPathComponent(bundleName + ".bundle")
-                if let bundle = bundlePathiOS.flatMap(Bundle.init(url:)) {
-                    return bundle
-                }
-            }
-        }
-        fatalError("unable to find bundle named \(bundleNames)")
-    }()
-}
-{% endif %}
+{% include "Bundle+extension.swift.stencil.include" %}

--- a/Sources/XcodeExport/Resources/UIColor+extension.swift.stencil
+++ b/Sources/XcodeExport/Resources/UIColor+extension.swift.stencil
@@ -1,10 +1,14 @@
 {% include "header.stencil" %}
 import UIKit
-{% if assetsInSwiftPackage %}
+{% if assetsInSwiftPackage and resourceBundleNames %}
+private class BundleProvider {
+    static let bundle = Bundle._module
+}
+{% elif assetsInSwiftPackage and not resourceBundleNames %}
 private class BundleProvider {
     static let bundle = Bundle.module
 }
-{% elif not assetsInMainBundle %}
+{% elif not assetsInSwiftPackage and not resourceBundleNames %}
 private class BundleProvider {
     static let bundle = Bundle(for: BundleProvider.self)
 }
@@ -25,3 +29,37 @@ public extension UIColor {{ "{" }}{% for color in colors %}{% if colorFromAssetC
         UIColor(red: {{ color.red }}, green: {{ color.green }}, blue: {{ color.blue }}, alpha: {{ color.alpha }})
     }{% endif %}{% endif %}{% endfor %}
 }
+{% if resourceBundleNames %}
+private extension Foundation.Bundle {
+    private class BundleFinder {}
+
+    // Returns the resource bundle associated with the current Swift module.
+    static var _module: Bundle = {
+        let bundleNames = {{ resourceBundleNames }}
+
+        let candidates = [
+            // Bundle should be present here when the package is linked into an App.
+            Bundle.main.resourceURL,
+            // Bundle should be present here when the package is linked into a framework.
+            Bundle(for: BundleFinder.self).resourceURL,
+            // Bundle should be present here when the package is used in UI Tests.
+            Bundle(for: BundleFinder.self).resourceURL?.deletingLastPathComponent(),
+            // For command-line tools.
+            Bundle.main.bundleURL,
+            // Bundle should be present here when running previews from a different package (this is the path to "…/Debug-iphonesimulator/").
+            Bundle(for: BundleFinder.self).resourceURL?.deletingLastPathComponent().deletingLastPathComponent().deletingLastPathComponent(),
+            Bundle(for: BundleFinder.self).resourceURL?.deletingLastPathComponent().deletingLastPathComponent()
+        ]
+
+        for candidate in candidates {
+            for bundleName in bundleNames {
+                let bundlePathiOS = candidate?.appendingPathComponent(bundleName + ".bundle")
+                if let bundle = bundlePathiOS.flatMap(Bundle.init(url:)) {
+                    return bundle
+                }
+            }
+        }
+        fatalError("unable to find bundle named \(bundleNames)")
+    }()
+}
+{% endif %}

--- a/Sources/XcodeExport/Resources/UIColor+extension.swift.stencil
+++ b/Sources/XcodeExport/Resources/UIColor+extension.swift.stencil
@@ -29,37 +29,4 @@ public extension UIColor {{ "{" }}{% for color in colors %}{% if colorFromAssetC
         UIColor(red: {{ color.red }}, green: {{ color.green }}, blue: {{ color.blue }}, alpha: {{ color.alpha }})
     }{% endif %}{% endif %}{% endfor %}
 }
-{% if resourceBundleNames %}
-private extension Foundation.Bundle {
-    private class BundleFinder {}
-
-    // Returns the resource bundle associated with the current Swift module.
-    static var _module: Bundle = {
-        let bundleNames = {{ resourceBundleNames }}
-
-        let candidates = [
-            // Bundle should be present here when the package is linked into an App.
-            Bundle.main.resourceURL,
-            // Bundle should be present here when the package is linked into a framework.
-            Bundle(for: BundleFinder.self).resourceURL,
-            // Bundle should be present here when the package is used in UI Tests.
-            Bundle(for: BundleFinder.self).resourceURL?.deletingLastPathComponent(),
-            // For command-line tools.
-            Bundle.main.bundleURL,
-            // Bundle should be present here when running previews from a different package (this is the path to "…/Debug-iphonesimulator/").
-            Bundle(for: BundleFinder.self).resourceURL?.deletingLastPathComponent().deletingLastPathComponent().deletingLastPathComponent(),
-            Bundle(for: BundleFinder.self).resourceURL?.deletingLastPathComponent().deletingLastPathComponent()
-        ]
-
-        for candidate in candidates {
-            for bundleName in bundleNames {
-                let bundlePathiOS = candidate?.appendingPathComponent(bundleName + ".bundle")
-                if let bundle = bundlePathiOS.flatMap(Bundle.init(url:)) {
-                    return bundle
-                }
-            }
-        }
-        fatalError("unable to find bundle named \(bundleNames)")
-    }()
-}
-{% endif %}
+{% include "Bundle+extension.swift.stencil.include" %}

--- a/Sources/XcodeExport/Resources/UIImage+extension.swift.stencil
+++ b/Sources/XcodeExport/Resources/UIImage+extension.swift.stencil
@@ -1,13 +1,51 @@
 {% include "header.stencil" %}
 import UIKit
-{% if assetsInSwiftPackage %}
+{% if assetsInSwiftPackage and resourceBundleNames %}
+private class BundleProvider {
+    static let bundle = Bundle._module
+}
+{% elif assetsInSwiftPackage and not resourceBundleNames %}
 private class BundleProvider {
     static let bundle = Bundle.module
 }
-{% elif not assetsInMainBundle %}
+{% elif not assetsInSwiftPackage and not resourceBundleNames %}
 private class BundleProvider {
     static let bundle = Bundle(for: BundleProvider.self)
 }
 {% endif %}
 public extension UIImage {{ "{" }}{% include "UIImage+extension.swift.stencil.include" %}
 }
+{% if resourceBundleNames %}
+private extension Foundation.Bundle {
+    private class BundleFinder {}
+
+    // Returns the resource bundle associated with the current Swift module.
+    static var _module: Bundle = {
+        let bundleNames = {{ resourceBundleNames }}
+
+        let candidates = [
+            // Bundle should be present here when the package is linked into an App.
+            Bundle.main.resourceURL,
+            // Bundle should be present here when the package is linked into a framework.
+            Bundle(for: BundleFinder.self).resourceURL,
+            // Bundle should be present here when the package is used in UI Tests.
+            Bundle(for: BundleFinder.self).resourceURL?.deletingLastPathComponent(),
+            // For command-line tools.
+            Bundle.main.bundleURL,
+            // Bundle should be present here when running previews from a different package (this is the path to "…/Debug-iphonesimulator/").
+            Bundle(for: BundleFinder.self).resourceURL?.deletingLastPathComponent().deletingLastPathComponent().deletingLastPathComponent(),
+            Bundle(for: BundleFinder.self).resourceURL?.deletingLastPathComponent().deletingLastPathComponent()
+        ]
+
+        for candidate in candidates {
+            for bundleName in bundleNames {
+                let bundlePathiOS = candidate?.appendingPathComponent(bundleName + ".bundle")
+                if let bundle = bundlePathiOS.flatMap(Bundle.init(url:)) {
+                    return bundle
+                }
+            }
+        }
+        fatalError("unable to find bundle named \(bundleNames)")
+    }()
+}
+{% endif %}

--- a/Sources/XcodeExport/Resources/UIImage+extension.swift.stencil
+++ b/Sources/XcodeExport/Resources/UIImage+extension.swift.stencil
@@ -15,37 +15,4 @@ private class BundleProvider {
 {% endif %}
 public extension UIImage {{ "{" }}{% include "UIImage+extension.swift.stencil.include" %}
 }
-{% if resourceBundleNames %}
-private extension Foundation.Bundle {
-    private class BundleFinder {}
-
-    // Returns the resource bundle associated with the current Swift module.
-    static var _module: Bundle = {
-        let bundleNames = {{ resourceBundleNames }}
-
-        let candidates = [
-            // Bundle should be present here when the package is linked into an App.
-            Bundle.main.resourceURL,
-            // Bundle should be present here when the package is linked into a framework.
-            Bundle(for: BundleFinder.self).resourceURL,
-            // Bundle should be present here when the package is used in UI Tests.
-            Bundle(for: BundleFinder.self).resourceURL?.deletingLastPathComponent(),
-            // For command-line tools.
-            Bundle.main.bundleURL,
-            // Bundle should be present here when running previews from a different package (this is the path to "…/Debug-iphonesimulator/").
-            Bundle(for: BundleFinder.self).resourceURL?.deletingLastPathComponent().deletingLastPathComponent().deletingLastPathComponent(),
-            Bundle(for: BundleFinder.self).resourceURL?.deletingLastPathComponent().deletingLastPathComponent()
-        ]
-
-        for candidate in candidates {
-            for bundleName in bundleNames {
-                let bundlePathiOS = candidate?.appendingPathComponent(bundleName + ".bundle")
-                if let bundle = bundlePathiOS.flatMap(Bundle.init(url:)) {
-                    return bundle
-                }
-            }
-        }
-        fatalError("unable to find bundle named \(bundleNames)")
-    }()
-}
-{% endif %}
+{% include "Bundle+extension.swift.stencil.include" %}

--- a/Sources/XcodeExport/XcodeColorExporter.swift
+++ b/Sources/XcodeExport/XcodeColorExporter.swift
@@ -55,6 +55,7 @@ final public class XcodeColorExporter: XcodeExporterBase {
 
         let context: [String: Any] = [
             "assetsInSwiftPackage": output.assetsInSwiftPackage,
+            "resourceBundleNames": output.resourceBundleNames,
             "assetsInMainBundle": output.assetsInMainBundle,
             "useNamespace": output.groupUsingNamespace,
             "colors": colors,
@@ -105,6 +106,7 @@ final public class XcodeColorExporter: XcodeExporterBase {
 
         let context: [String: Any] = [
             "assetsInSwiftPackage": output.assetsInSwiftPackage,
+            "resourceBundleNames": output.resourceBundleNames,
             "addObjcPrefix": output.addObjcAttribute,
             "colorFromAssetCatalog": useAssets,
             "assetsInMainBundle": output.assetsInMainBundle,

--- a/Sources/XcodeExport/XcodeColorExporter.swift
+++ b/Sources/XcodeExport/XcodeColorExporter.swift
@@ -55,7 +55,7 @@ final public class XcodeColorExporter: XcodeExporterBase {
 
         let context: [String: Any] = [
             "assetsInSwiftPackage": output.assetsInSwiftPackage,
-            "resourceBundleNames": output.resourceBundleNames,
+            "resourceBundleNames": output.resourceBundleNames ?? [],
             "assetsInMainBundle": output.assetsInMainBundle,
             "useNamespace": output.groupUsingNamespace,
             "colors": colors,
@@ -106,7 +106,7 @@ final public class XcodeColorExporter: XcodeExporterBase {
 
         let context: [String: Any] = [
             "assetsInSwiftPackage": output.assetsInSwiftPackage,
-            "resourceBundleNames": output.resourceBundleNames,
+            "resourceBundleNames": output.resourceBundleNames ?? [],
             "addObjcPrefix": output.addObjcAttribute,
             "colorFromAssetCatalog": useAssets,
             "assetsInMainBundle": output.assetsInMainBundle,

--- a/Sources/XcodeExport/XcodeImagesExporterBase.swift
+++ b/Sources/XcodeExport/XcodeImagesExporterBase.swift
@@ -66,7 +66,7 @@ public class XcodeImagesExporterBase: XcodeExporterBase {
         let context: [String: Any] = [
             "addObjcPrefix": output.addObjcAttribute,
             "assetsInSwiftPackage": output.assetsInSwiftPackage,
-            "resourceBundleNames": output.resourceBundleNames,
+            "resourceBundleNames": output.resourceBundleNames ?? [],
             "assetsInMainBundle": output.assetsInMainBundle,
             "images": names.map { ["name": $0] },
         ]

--- a/Sources/XcodeExport/XcodeImagesExporterBase.swift
+++ b/Sources/XcodeExport/XcodeImagesExporterBase.swift
@@ -66,6 +66,7 @@ public class XcodeImagesExporterBase: XcodeExporterBase {
         let context: [String: Any] = [
             "addObjcPrefix": output.addObjcAttribute,
             "assetsInSwiftPackage": output.assetsInSwiftPackage,
+            "resourceBundleNames": output.resourceBundleNames,
             "assetsInMainBundle": output.assetsInMainBundle,
             "images": names.map { ["name": $0] },
         ]

--- a/Tests/XcodeExportTests/XcodeColorExporterTests.swift
+++ b/Tests/XcodeExportTests/XcodeColorExporterTests.swift
@@ -59,6 +59,10 @@ final class XcodeColorExporterTests: XCTestCase {
 
         import UIKit
 
+        private class BundleProvider {
+            static let bundle = Bundle(for: BundleProvider.self)
+        }
+
         public extension UIColor {
             static var colorPair1: UIColor {
                 UIColor { traitCollection -> UIColor in
@@ -97,6 +101,10 @@ final class XcodeColorExporterTests: XCTestCase {
 
         import UIKit
 
+        private class BundleProvider {
+            static let bundle = Bundle(for: BundleProvider.self)
+        }
+
         public extension UIColor {
             static var colorPair1: UIColor { UIColor(named: #function)! }
             static var colorPair2: UIColor { UIColor(named: #function)! }
@@ -129,6 +137,10 @@ final class XcodeColorExporterTests: XCTestCase {
         \(header)
 
         import UIKit
+
+        private class BundleProvider {
+            static let bundle = Bundle(for: BundleProvider.self)
+        }
 
         public extension UIColor {
             @objc static var colorPair1: UIColor { UIColor(named: #function)! }
@@ -221,6 +233,10 @@ final class XcodeColorExporterTests: XCTestCase {
 
         import SwiftUI
 
+        private class BundleProvider {
+            static let bundle = Bundle(for: BundleProvider.self)
+        }
+
         public extension Color {
             static var colorPair1: Color { Color(#function) }
             static var colorPair2: Color { Color(#function) }
@@ -291,6 +307,10 @@ final class XcodeColorExporterTests: XCTestCase {
 
         import UIKit
 
+        private class BundleProvider {
+            static let bundle = Bundle(for: BundleProvider.self)
+        }
+
         public extension UIColor {
             static var backgroundPrimary: UIColor { UIColor(named: "background/primary")! }
         }
@@ -312,6 +332,10 @@ final class XcodeColorExporterTests: XCTestCase {
         \(header)
 
         import UIKit
+
+        private class BundleProvider {
+            static let bundle = Bundle(for: BundleProvider.self)
+        }
 
         public extension UIColor {
             static var `class`: UIColor {

--- a/Tests/XcodeExportTests/XcodeIconsExporterTests.swift
+++ b/Tests/XcodeExportTests/XcodeIconsExporterTests.swift
@@ -49,6 +49,10 @@ final class XcodeIconsExporterTests: XCTestCase {
 
         import UIKit
 
+        private class BundleProvider {
+            static let bundle = Bundle(for: BundleProvider.self)
+        }
+
         public extension UIImage {
             static var image1: UIImage { UIImage(named: #function)! }
             static var image2: UIImage { UIImage(named: #function)! }
@@ -85,6 +89,10 @@ final class XcodeIconsExporterTests: XCTestCase {
         \(header)
 
         import UIKit
+
+        private class BundleProvider {
+            static let bundle = Bundle(for: BundleProvider.self)
+        }
 
         public extension UIImage {
             static var image1: UIImage { UIImage(named: #function)! }
@@ -124,6 +132,10 @@ final class XcodeIconsExporterTests: XCTestCase {
         \(header)
 
         import UIKit
+
+        private class BundleProvider {
+            static let bundle = Bundle(for: BundleProvider.self)
+        }
 
         public extension UIImage {
             @objc static var image1: UIImage { UIImage(named: #function)! }
@@ -166,6 +178,10 @@ final class XcodeIconsExporterTests: XCTestCase {
         \(header)
 
         import UIKit
+
+        private class BundleProvider {
+            static let bundle = Bundle(for: BundleProvider.self)
+        }
 
         public extension UIImage {
             @objc static var image1: UIImage { UIImage(named: #function)! }
@@ -359,6 +375,10 @@ final class XcodeIconsExporterTests: XCTestCase {
 
         import SwiftUI
 
+        private class BundleProvider {
+            static let bundle = Bundle(for: BundleProvider.self)
+        }
+
         public extension Image {
             static var image1: Image { Image(#function) }
             static var image2: Image { Image(#function) }
@@ -395,6 +415,10 @@ final class XcodeIconsExporterTests: XCTestCase {
         \(header)
 
         import SwiftUI
+
+        private class BundleProvider {
+            static let bundle = Bundle(for: BundleProvider.self)
+        }
 
         public extension Image {
             static var image1: Image { Image(#function) }
@@ -522,6 +546,10 @@ final class XcodeIconsExporterTests: XCTestCase {
 
         import UIKit
 
+        private class BundleProvider {
+            static let bundle = Bundle(for: BundleProvider.self)
+        }
+
         public extension UIImage {
             static var image1: UIImage { UIImage(named: #function)! }
             static var image2: UIImage { UIImage(named: #function)! }
@@ -571,6 +599,10 @@ final class XcodeIconsExporterTests: XCTestCase {
 
         import UIKit
 
+        private class BundleProvider {
+            static let bundle = Bundle(for: BundleProvider.self)
+        }
+
         public extension UIImage {
             static var image1: UIImage { UIImage(named: #function)! }
             static var image2: UIImage { UIImage(named: #function)! }
@@ -595,6 +627,10 @@ final class XcodeIconsExporterTests: XCTestCase {
         \(header)
 
         import UIKit
+
+        private class BundleProvider {
+            static let bundle = Bundle(for: BundleProvider.self)
+        }
 
         public extension UIImage {
             static var `class`: UIImage { UIImage(named: #function)! }


### PR DESCRIPTION
Hi, Thank you for an amazing utility!

Fixed SwiftUI preview crashes when accessing assets from a nested Swift Package.

## Crash Info

I have two modules the Presentation and the DesignSystem.
The DesignSystem module has Color extension generated by figma-export.
The Presentation module has SwiftUIView that using Color extension of DesignSystem.  As soon as it touches the assets from the DesignSystem module, the preview crashes.

![スクリーンショット 2022-05-29 18 49 48](https://user-images.githubusercontent.com/25205138/170862125-6936ec66-bca0-43b1-879a-5eedeeb58892.png)

## Reference
https://developer.apple.com/forums/thread/664295?login=true#reply-to-this-question
