### PR TITLE
Improved typography handling

### DIFF
--- a/Sources/FigmaExport/Input/Params.swift
+++ b/Sources/FigmaExport/Input/Params.swift
@@ -42,6 +42,7 @@ struct Params: Decodable {
         struct Typography: Decodable {
             let nameValidateRegexp: String?
             let nameReplaceRegexp: String?
+            let weightToNameMapping: [String: String]?
         }
 
         let colors: Colors?

--- a/Sources/FigmaExport/Loaders/TextStylesLoader.swift
+++ b/Sources/FigmaExport/Loaders/TextStylesLoader.swift
@@ -5,15 +5,15 @@ import FigmaExportCore
 final class TextStylesLoader {
     
     private let client: Client
-    private let params: Params.Figma
+    private let params: Params
 
-    init(client: Client, params: Params.Figma) {
+    init(client: Client, params: Params) {
         self.client = client
         self.params = params
     }
     
     func load() throws -> [TextStyle] {
-        return try loadTextStyles(fileId: params.lightFileId)
+        return try loadTextStyles(fileId: params.figma.lightFileId)
     }
     
     private func loadTextStyles(fileId: String) throws -> [TextStyle] {
@@ -43,7 +43,7 @@ final class TextStylesLoader {
             
             return TextStyle(
                 name: style.name,
-                fontName: textStyle.fontPostScriptName ?? textStyle.fontFamily ?? "",
+                fontName: createFontName(typeStyle: textStyle),
                 fontSize: textStyle.fontSize,
                 fontStyle: DynamicTypeStyle(rawValue: style.description),
                 lineHeight: lineHeight,
@@ -62,5 +62,12 @@ final class TextStylesLoader {
     private func loadNodes(fileId: String, nodeIds: [String]) throws -> [NodeId: Node] {
         let endpoint = NodesEndpoint(fileId: fileId, nodeIds: nodeIds)
         return try client.request(endpoint)
+    }
+
+    private func createFontName(typeStyle: TypeStyle) -> String {
+        if let psName = typeStyle.fontPostScriptName { return psName }
+        guard let fontFamily = typeStyle.fontFamily else { return "" }
+        guard let fontWeightName = params.common?.typography?.weightToNameMapping?[String(typeStyle.fontWeight)] else { return fontFamily }
+        return "\(fontFamily)-\(fontWeightName)"
     }
 }

--- a/Sources/FigmaExport/Subcommands/ExportTypography.swift
+++ b/Sources/FigmaExport/Subcommands/ExportTypography.swift
@@ -23,7 +23,7 @@ extension FigmaExportCommand {
             logger.info("Using FigmaExport \(FigmaExportCommand.version) to export typography.")
 
             logger.info("Fetching text styles. Please wait...")
-            let loader = TextStylesLoader(client: client, params: options.params.figma)
+            let loader = TextStylesLoader(client: client, params: options.params)
             let textStyles = try loader.load()
             
             if let ios = options.params.ios,


### PR DESCRIPTION
Good time of the day!

Recently in our team we've stumbled on case in which `postScriptName` from Figma API is null (for instance, Poppins Regular does not seem to be working correctly).
In this PR I've added a possibility to specify mapping for font weight to font type (like 400 -> Regular, etc.)
I've not added a tests yet as I would like to first get a greenlight on the idea itself and maybe some suggestions on the implementation (for instance I've no idea, for the life of me, why Yams is not able to parse [Double: String], but is able to parse [String: String]). 