### PR TITLE
Small improvement for snake case handling

### DIFF
--- a/Sources/FigmaExportCore/Extensions/StringCase.swift
+++ b/Sources/FigmaExportCore/Extensions/StringCase.swift
@@ -49,7 +49,7 @@ public extension String {
             if results.isEmpty && (character.isLetter || character.isNumber) {
                 results.append(String(character))
             } else if ((lastCharacter.isLetter || lastCharacter.isNumber) && character.isLowercase) ||
-                        (lastCharacter.isNumber && character.isNumber) {
+                        (lastCharacter.isNumber && character.isNumber) || (lastCharacter.isUppercase && character.isUppercase) {
                 results[results.count - 1] = results[results.count - 1] + String(character)
             } else if (character.isLetter || character.isNumber) {
                 results.append(String(character))

--- a/Tests/FigmaExportCoreTests/Extensions/StringCaseTests.swift
+++ b/Tests/FigmaExportCoreTests/Extensions/StringCaseTests.swift
@@ -7,6 +7,7 @@ final class StringCaseTests: XCTestCase {
         XCTAssertTrue("snake".isSnakeCase)
         XCTAssertTrue("snake_case".isSnakeCase)
         XCTAssertTrue("snake_case_example".isSnakeCase)
+        XCTAssertFalse("NOTSNAKECASE".isSnakeCase)
         XCTAssertFalse("not_a_SNAKECASE_String".isSnakeCase)
         XCTAssertFalse("notSnakeCase".isSnakeCase)
         XCTAssertFalse("AlsoNotSnakeCase".isSnakeCase)
@@ -16,6 +17,7 @@ final class StringCaseTests: XCTestCase {
         XCTAssertEqual("snakeCased".snakeCased(), "snake_cased")
         XCTAssertEqual("snake Cased_String".snakeCased(), "snake_cased_string")
         XCTAssertEqual("_this is*  not-Very%difficult".snakeCased(), "this_is_not_very_difficult")
+        XCTAssertEqual("snakeCASE".snakeCased(), "snake_case")
     }
     
     func testLowerCamelCase() throws {


### PR DESCRIPTION
Good time of the day!

I created a small improvement to the way snake case is handled. Right now if you have (for instance) "Icon=WIFI 24" it will be translated into "icon_w_i_f_i_24". With this update it will be "icon_wifi_24", which, I think, is better.

I'm not sure about tests though, haven't found any for this function. Any pointers?