### PR TITLE
Modify SwiftUI Color extension to extend ShapeStyle

### DIFF
--- a/Sources/XcodeExport/Resources/Color+extension.swift.stencil
+++ b/Sources/XcodeExport/Resources/Color+extension.swift.stencil
@@ -13,7 +13,7 @@ private class BundleProvider {
     static let bundle = Bundle(for: BundleProvider.self)
 }
 {% endif %}
-public extension Color {{ "{" }}{% for color in colors %}
+public extension ShapeStyle where Self == Color {{ "{" }}{% for color in colors %}
     static var {{ color.name }}: Color { Color({% if useNamespace %}"{{ color.originalName }}"{% else %}#function{% endif %}{% if not assetsInMainBundle %}, bundle: BundleProvider.bundle{% endif %}) }{% endfor %}
 }
 {% include "Bundle+extension.swift.stencil.include" %}

--- a/Tests/XcodeExportTests/XcodeColorExporterTests.swift
+++ b/Tests/XcodeExportTests/XcodeColorExporterTests.swift
@@ -237,7 +237,7 @@ final class XcodeColorExporterTests: XCTestCase {
             static let bundle = Bundle(for: BundleProvider.self)
         }
 
-        public extension Color {
+        public extension ShapeStyle where Self == Color {
             static var colorPair1: Color { Color(#function) }
             static var colorPair2: Color { Color(#function) }
         }
@@ -274,7 +274,7 @@ final class XcodeColorExporterTests: XCTestCase {
             static let bundle = Bundle.module
         }
 
-        public extension Color {
+        public extension ShapeStyle where Self == Color {
             static var colorPair1: Color { Color(#function, bundle: BundleProvider.bundle) }
             static var colorPair2: Color { Color(#function, bundle: BundleProvider.bundle) }
         }


### PR DESCRIPTION
This change intends expand the usage of the generated SwiftUI color extension.

> Color conforms to a bigger style called ShapeStyle and this allows us to use Colors, Gradients, Materials and more as if they were the same thing. This ShapeStyle protocol is what background uses. This allows us to use these colors everywhere SwiftUI expects a ShapeStyle to be given.
https://www.hackingwithswift.com/books/ios-swiftui/formatting-our-mission-view

Additional discussion about the topic: https://www.hackingwithswift.com/forums/100-days-of-swiftui/extending-shapestyle-for-adding-colors-instead-of-extending-color/12324

I've found that I can create custom templates via `templatesPath` configuration but I still believe that defaulting to this would be better overall.