### PR TITLE
Null as default value for nullable contentDescription

### DIFF
--- a/Sources/AndroidExport/Resources/Icons.kt.stencil
+++ b/Sources/AndroidExport/Resources/Icons.kt.stencil
@@ -13,7 +13,7 @@ object Icons
 {% for icon in icons %}
 @Composable
 fun Icons.{{ icon.functionName }}(
-    contentDescription: String?,
+    contentDescription: String? = null,
     modifier: Modifier = Modifier,
     tint: Color = Color.Unspecified
 ) {

--- a/Tests/AndroidExportTests/AndroidComposeIconExporterTests.swift
+++ b/Tests/AndroidExportTests/AndroidComposeIconExporterTests.swift
@@ -46,7 +46,7 @@ final class AndroidComposeIconExporterTests: XCTestCase {
         
         @Composable
         fun Icons.TestIcon1(
-            contentDescription: String?,
+            contentDescription: String? = null,
             modifier: Modifier = Modifier,
             tint: Color = Color.Unspecified
         ) {
@@ -60,7 +60,7 @@ final class AndroidComposeIconExporterTests: XCTestCase {
         
         @Composable
         fun Icons.TestIcon2(
-            contentDescription: String?,
+            contentDescription: String? = null,
             modifier: Modifier = Modifier,
             tint: Color = Color.Unspecified
         ) {


### PR DESCRIPTION
Having null as default simplifies the usage as contentDescription might not always be something a developer wants to add and not having to add null makes life i bit easier