### PR TITLE
Add StencilSwiftKit

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -11,12 +11,39 @@
         }
       },
       {
+        "package": "Komondor",
+        "repositoryURL": "https://github.com/shibapm/Komondor.git",
+        "state": {
+          "branch": null,
+          "revision": "90b087b1e39069684b1ff4bf915c2aae594f2d60",
+          "version": "1.1.3"
+        }
+      },
+      {
+        "package": "PackageConfig",
+        "repositoryURL": "https://github.com/shibapm/PackageConfig.git",
+        "state": {
+          "branch": null,
+          "revision": "58523193c26fb821ed1720dcd8a21009055c7cdb",
+          "version": "1.1.3"
+        }
+      },
+      {
         "package": "PathKit",
         "repositoryURL": "https://github.com/kylef/PathKit.git",
         "state": {
           "branch": null,
           "revision": "3bfd2737b700b9a36565a8c94f4ad2b050a5e574",
           "version": "1.0.1"
+        }
+      },
+      {
+        "package": "ShellOut",
+        "repositoryURL": "https://github.com/JohnSundell/ShellOut.git",
+        "state": {
+          "branch": null,
+          "revision": "e1577acf2b6e90086d01a6d5e2b8efdaae033568",
+          "version": "2.3.0"
         }
       },
       {
@@ -33,8 +60,17 @@
         "repositoryURL": "https://github.com/stencilproject/Stencil.git",
         "state": {
           "branch": null,
-          "revision": "ccd9402682f4c07dac9561befd207c8156e80e20",
-          "version": "0.14.2"
+          "revision": "4f222ac85d673f35df29962fc4c36ccfdaf9da5b",
+          "version": "0.15.1"
+        }
+      },
+      {
+        "package": "StencilSwiftKit",
+        "repositoryURL": "https://github.com/SwiftGen/StencilSwiftKit",
+        "state": {
+          "branch": null,
+          "revision": "20e2de5322c83df005939d9d9300fab130b49f97",
+          "version": "2.10.1"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -15,7 +15,8 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-argument-parser", from: "1.0.0"),
         .package(url: "https://github.com/jpsim/Yams.git", from: "4.0.0"),
         .package(url: "https://github.com/apple/swift-log.git", from: "1.4.0"),
-        .package(url: "https://github.com/stencilproject/Stencil.git", from: "0.14.2"),
+        .package(url: "https://github.com/stencilproject/Stencil.git", from: "0.15.1"),
+        .package(url: "https://github.com/SwiftGen/StencilSwiftKit", from: "2.10.1"),
         .package(url: "https://github.com/tuist/XcodeProj.git", from: "8.5.0"),
         .package(url: "https://github.com/pointfreeco/swift-custom-dump", from: "0.3.0")
     ],
@@ -45,7 +46,10 @@ let package = Package(
         // Exports resources to Xcode project
         .target(
             name: "XcodeExport",
-            dependencies: ["FigmaExportCore", .product(name: "Stencil", package: "Stencil")],
+            dependencies: [
+                "FigmaExportCore", .product(name: "Stencil", package: "Stencil"),
+                "StencilSwiftKit"
+            ],
 			resources: [
               	.copy("Resources/")
 	        ]
@@ -54,7 +58,7 @@ let package = Package(
         // Exports resources to Android project
         .target(
             name: "AndroidExport",
-            dependencies: ["FigmaExportCore", "Stencil"],
+            dependencies: ["FigmaExportCore", "Stencil", "StencilSwiftKit"],
             resources: [
                 .copy("Resources/")
             ]
@@ -72,7 +76,10 @@ let package = Package(
         ),
         .testTarget(
             name: "XcodeExportTests",
-            dependencies: ["XcodeExport", .product(name: "CustomDump", package: "swift-custom-dump")]
+            dependencies: [
+                "XcodeExport", .product(name: "CustomDump", package: "swift-custom-dump"),
+                "StencilSwiftKit"
+            ]
         ),
         .testTarget(
             name: "AndroidExportTests",

--- a/Sources/AndroidExport/AndroidExporter.swift
+++ b/Sources/AndroidExport/AndroidExporter.swift
@@ -2,6 +2,7 @@ import Stencil
 import PathKit
 import Foundation
 import FigmaExportCore
+import StencilSwiftKit
 
 public class AndroidExporter {
     
@@ -21,7 +22,9 @@ public class AndroidExporter {
                 Path(Bundle.module.resourcePath!)
             ])
         }
-        return Environment(loader: loader)
+        let ext = Extension()
+        ext.registerStencilSwiftExtensions()
+        return Environment(loader: loader, extensions: [ext])
     }
     
     func makeFileContents(for string: String, directory: URL, file: URL) throws -> FileContents {

--- a/Sources/XcodeExport/XcodeExporterBase.swift
+++ b/Sources/XcodeExport/XcodeExporterBase.swift
@@ -2,6 +2,7 @@ import FigmaExportCore
 import Foundation
 import Stencil
 import PathKit
+import StencilSwiftKit
 
 public class XcodeExporterBase {
     
@@ -34,7 +35,9 @@ public class XcodeExporterBase {
                 Path(Bundle.module.resourcePath!)
             ])
         }
-        return Environment(loader: loader)
+        let ext = Extension()
+        ext.registerStencilSwiftExtensions()
+        return Environment(loader: loader, extensions: [ext])
     }
     
     func makeFileContents(for string: String, url: URL) throws -> FileContents {


### PR DESCRIPTION
### What did

- Up Stencil version to 0.15.1
- Added [StencilSwiftKit](https://github.com/SwiftGen/StencilSwiftKit/tree/402aaf406b6f0ad70effa2e055b2ea7541fbd100)

### Motivation

Add new nodes & filters dedicated to Swift code generation.