### PR TITLE
Add xmlOutputFileName for androidConfig.colors

### DIFF
--- a/Sources/AndroidExport/AndroidColorExporter.swift
+++ b/Sources/AndroidExport/AndroidColorExporter.swift
@@ -6,9 +6,11 @@ import PathKit
 final public class AndroidColorExporter: AndroidExporter {
 
     private let output: AndroidOutput
+    private let xmlOutputFileName: String
 
-    public init(output: AndroidOutput) {
+    public init(output: AndroidOutput, xmlOutputFileName: String?) {
         self.output = output
+        self.xmlOutputFileName = xmlOutputFileName ?? "colors.xml"
         super.init(templatesPath: output.templatesPath)
     }
     
@@ -45,7 +47,7 @@ final public class AndroidColorExporter: AndroidExporter {
         let contents = try makeColorsContents(colorPairs, dark: dark)
         
         let directoryURL = output.xmlOutputDirectory.appendingPathComponent(dark ? "values-night" : "values")
-        let fileURL = URL(string: "colors.xml")!
+        let fileURL = URL(string: xmlOutputFileName)!
         
         return try makeFileContents(for: contents, directory: directoryURL, file: fileURL)
     }

--- a/Sources/FigmaExport/Input/Params.swift
+++ b/Sources/FigmaExport/Input/Params.swift
@@ -121,6 +121,7 @@ struct Params: Decodable {
             let composePackageName: String?
         }
         struct Colors: Decodable {
+            let xmlOutputFileName: String?
             let composePackageName: String?
         }
         struct Images: Decodable {

--- a/Sources/FigmaExport/Resources/androidConfig.swift
+++ b/Sources/FigmaExport/Resources/androidConfig.swift
@@ -64,6 +64,8 @@ android:
   colors:
     # [optional] The package to export the Jetpack Compose color code to. Note: To export Jetpack Compose code, also `mainSrc` and `resourcePackage` above must be set 
     composePackageName: "com.example"
+    # [optional] File name for XML file with exported colors (default is "colors.xml")
+    xmlOutputFileName: "colors.xml"
   # Parameters for exporting icons
   icons:
     # Where to place icons relative to `mainRes`? FigmaExport clears this directory every time your execute `figma-export icons` command

--- a/Sources/FigmaExport/Subcommands/ExportColors.swift
+++ b/Sources/FigmaExport/Subcommands/ExportColors.swift
@@ -140,11 +140,13 @@ extension FigmaExportCommand {
                 packageName: androidParams.colors?.composePackageName,
                 templatesPath: androidParams.templatesPath
             )
-            let exporter = AndroidColorExporter(output: output)
+            let exporter = AndroidColorExporter(output: output, xmlOutputFileName: androidParams.colors?.xmlOutputFileName)
             let files = try exporter.export(colorPairs: colorPairs)
             
-            let lightColorsFileURL = androidParams.mainRes.appendingPathComponent("values/colors.xml")
-            let darkColorsFileURL = androidParams.mainRes.appendingPathComponent("values-night/colors.xml")
+            let fileName = androidParams.colors?.xmlOutputFileName ?? "colors.xml"
+            
+            let lightColorsFileURL = androidParams.mainRes.appendingPathComponent("values/" + fileName)
+            let darkColorsFileURL = androidParams.mainRes.appendingPathComponent("values-night/" + fileName)
             
             try? FileManager.default.removeItem(atPath: lightColorsFileURL.path)
             try? FileManager.default.removeItem(atPath: darkColorsFileURL.path)

--- a/Tests/AndroidExportTests/AndroidColorExporterTests.swift
+++ b/Tests/AndroidExportTests/AndroidColorExporterTests.swift
@@ -30,7 +30,7 @@ final class AndroidColorExporterTests: XCTestCase {
     // MARK: - Setup
     
     func testExport() throws {
-        let exporter = AndroidColorExporter(output: output)
+        let exporter = AndroidColorExporter(output: output, xmlOutputFileName: nil)
 
         let result = try exporter.export(colorPairs: [colorPair1, colorPair2])
         XCTAssertEqual(result.count, 3)


### PR DESCRIPTION
It is difficult to integrate figma-export into already written project. It usually has own colors.xml file with project-specific color-resources.  And figma-export ouput is hardcorded into colors.xml, so it will conflict with already written file colors.xml. This PR adds optional field to setup output file name (only for colors and only for XML)

Also, devs will ruin autogenerated file cause they already habits to edit colors.xml (I guess autogenerated file should have name like "colors_autogenerated.xml")