### PR TITLE
Sort icons Array before passing to exportIcons

### DIFF
--- a/Sources/FigmaExport/Subcommands/ExportIcons.swift
+++ b/Sources/FigmaExport/Subcommands/ExportIcons.swift
@@ -218,7 +218,7 @@ extension FigmaExportCommand {
             }.map { fileContents -> String in
                 fileContents.destination.file.deletingPathExtension().lastPathComponent
             })
-            let composeFile = try composeExporter.exportIcons(iconNames: Array(composeIconNames))
+            let composeFile = try composeExporter.exportIcons(iconNames: Array(composeIconNames).sorted())
             composeFile.map { localFiles.append($0) }
 
             logger.info("Writing files to Android Studio project...")


### PR DESCRIPTION
Hi, I'm using figma-export in our Android team.
I'm very satisfied with this tool. Thank you!

But I'm worried about that every time executing figma-export producing different output of `Icons.kt` because `icons` in `Icons.kt.stencil` contains different ordered items.
So I added `.sorted()` before passing Array to `icons`.

This will produce constant `Icons.kt` file every time.

I will hope you to merge this PR.
Thank you.