### PR TITLE
Fix params order for compose functions

### DIFF
--- a/Sources/AndroidExport/Resources/Icons.kt.stencil
+++ b/Sources/AndroidExport/Resources/Icons.kt.stencil
@@ -16,8 +16,8 @@ object Icons
 {% for icon in icons %}
 @Composable
 fun Icons.{{ icon.functionName }}(
-    contentDescription: String? = null,
     modifier: Modifier = Modifier,
+    contentDescription: String? = null,
     tint: Color = Color.Unspecified
 ) {
     Icon(


### PR DESCRIPTION
I use [those detekt rules](https://mrmans0n.github.io/compose-rules/rules/#ordering-composable-parameters-properly) and it throws an error that order of compose function params is incorrect after downloading new ones. I decided that it will be better to fix "root cause" here instead of blowing up my baseline file