### PR TITLE
fix: skip remote variable collections when matching by name

### DIFF
--- a/Sources/FigmaAPI/Model/Variables.swift
+++ b/Sources/FigmaAPI/Model/Variables.swift
@@ -7,6 +7,7 @@ public struct VariableCollectionValue: Decodable {
     public var defaultModeId: String
     public var id: String
     public var name: String
+    public var remote: Bool?
     public var modes: [Mode]
     public var variableIds: [String]
 }

--- a/Sources/FigmaExport/Loaders/Colors/ColorsVariablesLoader.swift
+++ b/Sources/FigmaExport/Loaders/Colors/ColorsVariablesLoader.swift
@@ -26,7 +26,7 @@ final class ColorsVariablesLoader {
 
         let meta = try loadVariables(fileId: tokensFileId)
 
-        guard let tokenCollection = meta.variableCollections.first(where: { $0.value.name == tokensCollectionName })
+        guard let tokenCollection = meta.variableCollections.first(where: { $0.value.name == tokensCollectionName && $0.value.remote != true })
         else { throw FigmaExportError.custom(errorString: "tokensCollectionName not found" ) }
 
         let variables: [Variable] = tokenCollection.value.variableIds.compactMap { tokenId in

--- a/Tests/FigmaAPITests/VariablesTests.swift
+++ b/Tests/FigmaAPITests/VariablesTests.swift
@@ -1,0 +1,38 @@
+import XCTest
+import Foundation
+@testable import FigmaAPI
+
+final class VariablesTests: XCTestCase {
+
+    func testLookupPrefersLocalOverRemoteWithSameName() throws {
+        let localId = "VariableCollectionId:1:4"
+        let remoteId = "VariableCollectionId:abc123def456/1:9"
+
+        let collections: [String: VariableCollectionValue] = [
+            localId: VariableCollectionValue(
+                defaultModeId: "1:0",
+                id: localId,
+                name: "Colors",
+                remote: false,
+                modes: [Mode(modeId: "1:0", name: "Light")],
+                variableIds: ["var1", "var2", "var3"]
+            ),
+            remoteId: VariableCollectionValue(
+                defaultModeId: "1:0",
+                id: remoteId,
+                name: "Colors",
+                remote: true,
+                modes: [Mode(modeId: "1:0", name: "Light")],
+                variableIds: ["var1"]
+            )
+        ]
+
+        let match = collections.first(where: {
+            $0.value.name == "Colors" && $0.value.remote != true
+        })
+
+        XCTAssertNotNil(match)
+        XCTAssertEqual(match?.key, localId)
+        XCTAssertEqual(match?.value.variableIds.count, 3)
+    }
+}


### PR DESCRIPTION
When using `variablesColors`, the Figma REST API (`GET /v1/files/:id/variables/local`) returns both local and remote (library-subscribed) variable collections. 

If a remote collection shares the same name as a local one, `.first(where:)` may match the remote collection instead, which in my org contains fewer variables, leading to silently missing colors in the export.

Fix: Decode the `remote` field from the API response on `VariableCollectionValue` and filter it out during collection lookup:

The remote field is documented by Figma (https://developers.figma.com/docs/rest-api/variables-types/#variablecollection-type) as: 

> Whether the variable collection is remote. 