### PR TITLE
Update the `svgSimplifyStroke` default to be `true`

### DIFF
--- a/Sources/FigmaAPI/Endpoint/ImageEndpoint.swift
+++ b/Sources/FigmaAPI/Endpoint/ImageEndpoint.swift
@@ -34,7 +34,7 @@ public class SVGParams: FormatParams {
     public var svgIncludeId = false
 
     /// Whether to simplify inside/outside strokes and use stroke attribute if possible instead of <mask>. Default: true.
-    public var svgSimplifyStroke = false
+    public var svgSimplifyStroke = true
 
     public init() {
         super.init(format: "svg")

--- a/Sources/FigmaExport/FigmaExportCommand.swift
+++ b/Sources/FigmaExport/FigmaExportCommand.swift
@@ -3,14 +3,14 @@ import Foundation
 import Logging
 
 enum FigmaExportError: LocalizedError {
-    
+
     case invalidFileName(String)
     case stylesNotFound
     case componentsNotFound
     case accessTokenNotFound
     case colorsAssetsFolderNotSpecified
     case custom(errorString: String)
-    
+
     var errorDescription: String? {
         switch self {
         case .invalidFileName(let name):
@@ -31,14 +31,14 @@ enum FigmaExportError: LocalizedError {
 
 @main
 struct FigmaExportCommand: ParsableCommand {
-    
-    static let version = "0.38.4"
-    
+
+    static let version = "0.39.0"
+
     static let svgFileConverter = VectorDrawableConverter()
     static let fileWriter = FileWriter()
     static let fileDownloader = FileDownloader()
     static let logger = Logger(label: "com.redmadrobot.figma-export")
-    
+
     static var configuration = CommandConfiguration(
         commandName: "figma-export",
         abstract: "Exports resources from Figma",


### PR DESCRIPTION
This brings the default in line with the documentation comments, and fixes #259.

In our testing our other icons weren't affected, though an expanded feature that support setting this value may be warranted.